### PR TITLE
remove thread per workers and re run notebooks with latest protoplast

### DIFF
--- a/notebooks/classification_examples.ipynb
+++ b/notebooks/classification_examples.ipynb
@@ -1,1793 +1,1808 @@
 {
-  "cells": [
-    {
-      "cell_type": "markdown",
-      "id": "MJUe",
-      "metadata": {},
-      "source": [
-        "# Classification Models for Single-Cell Data with PROTOplast"
-      ]
-    },
-    {
-      "cell_type": "markdown",
-      "id": "453a8f1a",
-      "metadata": {},
-      "source": [
-        "This tutorial demonstrates how to use PROTOplast to train different classification models in PyTorch with the `h5ad` format."
-      ]
-    },
-    {
-      "cell_type": "markdown",
-      "id": "2713b010",
-      "metadata": {},
-      "source": [
-        "**Download the Tahoe-100M `h5ad` files**\n",
-        "- The Tahoe-100M dataset can be downloaded in `h5ad` format from the **Arc Institute Google Cloud Storage**.\n",
-        "- For step-by-step instructions, see the [official tutorial](https://github.com/ArcInstitute/arc-virtual-cell-atlas/blob/main/tahoe-100M/README.md)."
-      ]
-    },
-    {
-      "cell_type": "markdown",
-      "id": "vblA",
-      "metadata": {},
-      "source": [
-        "**Setup**  \n",
-        "- Configure the training environment for single-cell RNA sequencing (scRNA-seq) data using **PROTOplast** in combination with **PyTorch Lightning** and **Ray**."
-      ]
-    },
-    {
-      "cell_type": "code",
-      "execution_count": 1,
-      "id": "bkHC",
-      "metadata": {},
-      "outputs": [
-        {
-          "name": "stderr",
-          "output_type": "stream",
-          "text": [
-            "/mnt/hdd1/dung/protoplast-ml-example/.venv/lib/python3.11/site-packages/tqdm/auto.py:21: TqdmWarning: IProgress not found. Please update jupyter and ipywidgets. See https://ipywidgets.readthedocs.io/en/stable/user_install.html\n",
-            "  from .autonotebook import tqdm as notebook_tqdm\n",
-            "2025-09-24 10:35:30,416\tINFO util.py:154 -- Missing packages: ['ipywidgets']. Run `pip install -U ipywidgets`, then restart the notebook server for rich notebook output.\n"
-          ]
-        },
-        {
-          "name": "stdout",
-          "output_type": "stream",
-          "text": [
-            "\u2713 Applied AnnDataFileManager patch\n"
-          ]
-        },
-        {
-          "name": "stderr",
-          "output_type": "stream",
-          "text": [
-            "2025-09-24 10:35:36,024\tINFO util.py:154 -- Missing packages: ['ipywidgets']. Run `pip install -U ipywidgets`, then restart the notebook server for rich notebook output.\n",
-            "2025-09-24 10:35:36,067\tINFO util.py:154 -- Missing packages: ['ipywidgets']. Run `pip install -U ipywidgets`, then restart the notebook server for rich notebook output.\n"
-          ]
-        },
-        {
-          "name": "stdout",
-          "output_type": "stream",
-          "text": [
-            "\u2713 Applied AnnDataFileManager patch\n",
-            "CPU times: user 18.5 s, sys: 1.25 s, total: 19.7 s\n",
-            "Wall time: 10.6 s\n"
-          ]
-        }
-      ],
-      "source": [
-        "%%time\n",
-        "import anndata\n",
-        "import numpy as np\n",
-        "import ray\n",
-        "\n",
-        "# models\n",
-        "from protoplast.scrna.anndata.lightning_models import LinearClassifier\n",
-        "from protoplast.scrna.anndata.torch_dataloader import DistributedCellLineAnnDataset as Dcl\n",
-        "from protoplast.scrna.anndata.torch_dataloader import cell_line_metadata_cb\n",
-        "from protoplast.scrna.anndata.trainer import RayTrainRunner\n",
-        "from ray.train.lightning import RayDDPStrategy\n",
-        "from scsims.model import SIMSClassifier\n",
-        "\n",
-        "# scvi training plan\n",
-        "## install scvi-tools if needed:\n",
-        "## uv add scvi-tools\n",
-        "from scvi.module import Classifier\n",
-        "from scvi.train import ClassifierTrainingPlan"
-      ]
-    },
-    {
-      "cell_type": "markdown",
-      "id": "6011fb16",
-      "metadata": {},
-      "source": [
-        "## 1. Load the Tahoe 100-M Dataset (`h5ad`)\n",
-        "- `file_paths`: Plate 12 from Tahoe-100M (The largest file: 35 GB) is used as a demo. To add more plates, append their `.h5ad` file paths to the list, separated by commas\n",
-        "- `thread_per_worker`: number of threads allocated per worker. The default value is `1`\n",
-        "- `batch_size`: number of samples per training batch\n",
-        "- `test_size`: fraction of data reserved for testing (use `0.0` if no test set is needed)\n",
-        "- `val_size`: fraction of data reserved for validation \n"
-      ]
-    },
-    {
-      "cell_type": "code",
-      "execution_count": 2,
-      "id": "Xref",
-      "metadata": {},
-      "outputs": [
-        {
-          "name": "stdout",
-          "output_type": "stream",
-          "text": [
-            "CPU times: user 17 \u03bcs, sys: 2 \u03bcs, total: 19 \u03bcs\n",
-            "Wall time: 34.3 \u03bcs\n"
-          ]
-        }
-      ],
-      "source": [
-        "%%time\n",
-        "file_paths = [\"/mnt/hdd2/tan/tahoe100m/plate12_filt_Vevo_Tahoe100M_WServicesFrom_ParseGigalab.h5ad\"]\n",
-        "thread_per_worker = 2\n",
-        "batch_size = 2000\n",
-        "test_size = 0.0\n",
-        "val_size = 0.2"
-      ]
-    },
-    {
-      "cell_type": "markdown",
-      "id": "SFPL",
-      "metadata": {},
-      "source": [
-        "## 2. Simple Classifier\n",
-        "\n",
-        "This example illustrates how to configure a training runner with **PROTOplast** and **Ray**.\n",
-        "\n",
-        "- `LinearClassifier`: a simple baseline model that can be swapped with a custom implementation\n",
-        "- `Dcl`: the dataset object for training, imported from `protoplast.scrna.anndata.torch_dataloader`\n",
-        "  - Defined as a subclass of `DistributedAnnDataset`, customized for cell line classification tasks\n",
-        "- `[\"num_genes\", \"num_classes\"]`: arguments that specify the model\u2019s input and output dimensions\n",
-        "- `cell_line_metadata_cb`: a callback function that attaches dataset-specific metadata, such as cell line labels and class counts"
-      ]
-    },
-    {
-      "cell_type": "code",
-      "execution_count": 3,
-      "id": "BYtC",
-      "metadata": {
-        "scrolled": true
-      },
-      "outputs": [
-        {
-          "name": "stderr",
-          "output_type": "stream",
-          "text": [
-            "2025-09-24 10:35:39,991\tINFO worker.py:1951 -- Started a local Ray instance.\n"
-          ]
-        },
-        {
-          "name": "stdout",
-          "output_type": "stream",
-          "text": [
-            "CPU times: user 216 ms, sys: 286 ms, total: 502 ms\n",
-            "Wall time: 3.83 s\n",
-            "\u001b[36m(TrainTrainable pid=1150735)\u001b[0m \u2713 Applied AnnDataFileManager patch\n",
-            "\u001b[36m(TrainTrainable pid=1150735)\u001b[0m \u2713 Applied AnnDataFileManager patch\n"
-          ]
-        },
-        {
-          "name": "stderr",
-          "output_type": "stream",
-          "text": [
-            "\u001b[36m(RayTrainWorker pid=1150881)\u001b[0m Setting up process group for: env:// [rank=0, world_size=1]\n",
-            "\u001b[36m(TorchTrainer pid=1150735)\u001b[0m Started distributed worker processes: \n",
-            "\u001b[36m(TorchTrainer pid=1150735)\u001b[0m - (node_id=c3fc7992c9dd18093e236be96e846423f856ed9a44226d1a5590ece9, ip=192.168.1.226, pid=1150881) world_rank=0, local_rank=0, node_rank=0\n"
-          ]
-        },
-        {
-          "name": "stdout",
-          "output_type": "stream",
-          "text": [
-            "\u001b[36m(RayTrainWorker pid=1150881)\u001b[0m \u2713 Applied AnnDataFileManager patch\n",
-            "\u001b[36m(RayTrainWorker pid=1150881)\u001b[0m \u2713 Applied AnnDataFileManager patch\n",
-            "\u001b[36m(RayTrainWorker pid=1150881)\u001b[0m =========Starting the training on 0 with num threads: 2=========\n"
-          ]
-        },
-        {
-          "name": "stderr",
-          "output_type": "stream",
-          "text": [
-            "\u001b[36m(RayTrainWorker pid=1150881)\u001b[0m \ud83d\udca1 Tip: For seamless cloud uploads and versioning, try installing [litmodels](https://pypi.org/project/litmodels/) to enable LitModelCheckpoint, which syncs automatically with the Lightning model registry.\n",
-            "\u001b[36m(RayTrainWorker pid=1150881)\u001b[0m GPU available: True (cuda), used: True\n",
-            "\u001b[36m(RayTrainWorker pid=1150881)\u001b[0m TPU available: False, using: 0 TPU cores\n",
-            "\u001b[36m(RayTrainWorker pid=1150881)\u001b[0m HPU available: False, using: 0 HPUs\n",
-            "\u001b[36m(RayTrainWorker pid=1150881)\u001b[0m /mnt/hdd1/dung/protoplast-ml-example/.venv/lib/python3.11/site-packages/lightning/fabric/plugins/environments/slurm.py:204: The `srun` command is available on your system but is not used. HINT: If your intention is to run Lightning on SLURM, prepend your python command with `srun` like so: srun python /mnt/hdd1/dung/protoplast-ml-example/.venv/lib/pytho ...\n",
-            "\u001b[36m(RayTrainWorker pid=1150881)\u001b[0m You are using a CUDA device ('NVIDIA GeForce RTX 3080') that has Tensor Cores. To properly utilize them, you should set `torch.set_float32_matmul_precision('medium' | 'high')` which will trade-off precision for performance. For more details, read https://pytorch.org/docs/stable/generated/torch.set_float32_matmul_precision.html#torch.set_float32_matmul_precision\n",
-            "\u001b[36m(RayTrainWorker pid=1150881)\u001b[0m LOCAL_RANK: 0 - CUDA_VISIBLE_DEVICES: [0]\n",
-            "\u001b[36m(RayTrainWorker pid=1150881)\u001b[0m \n",
-            "\u001b[36m(RayTrainWorker pid=1150881)\u001b[0m   | Name    | Type             | Params | Mode \n",
-            "\u001b[36m(RayTrainWorker pid=1150881)\u001b[0m -----------------------------------------------------\n",
-            "\u001b[36m(RayTrainWorker pid=1150881)\u001b[0m 0 | model   | Linear           | 3.1 M  | train\n",
-            "\u001b[36m(RayTrainWorker pid=1150881)\u001b[0m 1 | loss_fn | CrossEntropyLoss | 0      | train\n",
-            "\u001b[36m(RayTrainWorker pid=1150881)\u001b[0m -----------------------------------------------------\n",
-            "\u001b[36m(RayTrainWorker pid=1150881)\u001b[0m 3.1 M     Trainable params\n",
-            "\u001b[36m(RayTrainWorker pid=1150881)\u001b[0m 0         Non-trainable params\n",
-            "\u001b[36m(RayTrainWorker pid=1150881)\u001b[0m 3.1 M     Total params\n",
-            "\u001b[36m(RayTrainWorker pid=1150881)\u001b[0m 12.542    Total estimated model params size (MB)\n",
-            "\u001b[36m(RayTrainWorker pid=1150881)\u001b[0m 2         Modules in train mode\n",
-            "\u001b[36m(RayTrainWorker pid=1150881)\u001b[0m 0         Modules in eval mode\n",
-            "\u001b[36m(RayTrainWorker pid=1150881)\u001b[0m /mnt/hdd1/dung/protoplast-ml-example/.venv/lib/python3.11/site-packages/torch/distributed/distributed_c10d.py:4807: UserWarning: No device id is provided via `init_process_group` or `barrier `. Using the current device set by the user. \n",
-            "\u001b[36m(RayTrainWorker pid=1150881)\u001b[0m   warnings.warn(  # warn only once\n",
-            "\u001b[36m(RayTrainWorker pid=1150881)\u001b[0m /mnt/hdd1/dung/protoplast-ml-example/.venv/lib/python3.11/site-packages/lightning/pytorch/utilities/data.py:123: Your `IterableDataset` has `__len__` defined. In combination with multi-process data loading (when num_workers > 1), `__len__` could be inaccurate if each worker is not configured independently to avoid having duplicate data.\n"
-          ]
-        },
-        {
-          "name": "stdout",
-          "output_type": "stream",
-          "text": [
-            "Sanity Checking: |          | 0/? [00:00<?, ?it/s]\n"
-          ]
-        },
-        {
-          "name": "stderr",
-          "output_type": "stream",
-          "text": [
-            "\u001b[36m(RayTrainWorker pid=1150881)\u001b[0m /mnt/hdd1/dung/protoplast-ml-example/submodules/protoplast/src/protoplast/scrna/anndata/torch_dataloader.py:107: UserWarning: Sparse CSR tensor support is in beta state. If you miss a functionality in the sparse tensor support, please submit a feature request to https://github.com/pytorch/pytorch/issues. (Triggered internally at /pytorch/aten/src/ATen/SparseCsrTensorImpl.cpp:53.)\n",
-            "\u001b[36m(RayTrainWorker pid=1150881)\u001b[0m   return torch.sparse_csr_tensor(\n",
-            "\u001b[36m(RayTrainWorker pid=1150881)\u001b[0m /mnt/hdd1/dung/protoplast-ml-example/.venv/lib/python3.11/site-packages/torch/multiprocessing/reductions.py:473: UserWarning: Sparse CSR tensor support is in beta state. If you miss a functionality in the sparse tensor support, please submit a feature request to https://github.com/pytorch/pytorch/issues. (Triggered internally at /pytorch/aten/src/ATen/SparseCsrTensorImpl.cpp:53.)\n",
-            "\u001b[36m(RayTrainWorker pid=1150881)\u001b[0m   return torch.sparse_compressed_tensor(\n"
-          ]
-        },
-        {
-          "name": "stdout",
-          "output_type": "stream",
-          "text": [
-            "Sanity Checking DataLoader 0:   0%|          | 0/2 [00:00<?, ?it/s]\n",
-            "Sanity Checking DataLoader 0:  50%|\u2588\u2588\u2588\u2588\u2588     | 1/2 [00:00<00:00,  4.25it/s]\n",
-            "                                                                           \n"
-          ]
-        },
-        {
-          "name": "stderr",
-          "output_type": "stream",
-          "text": [
-            "\u001b[36m(RayTrainWorker pid=1150881)\u001b[0m /mnt/hdd1/dung/protoplast-ml-example/submodules/protoplast/src/protoplast/scrna/anndata/torch_dataloader.py:107: UserWarning: Sparse CSR tensor support is in beta state. If you miss a functionality in the sparse tensor support, please submit a feature request to https://github.com/pytorch/pytorch/issues. (Triggered internally at /pytorch/aten/src/ATen/SparseCsrTensorImpl.cpp:53.)\n",
-            "\u001b[36m(RayTrainWorker pid=1150881)\u001b[0m   return torch.sparse_csr_tensor(\n",
-            "\u001b[36m(RayTrainWorker pid=1150881)\u001b[0m /mnt/hdd1/dung/protoplast-ml-example/.venv/lib/python3.11/site-packages/lightning/pytorch/trainer/connectors/logger_connector/result.py:434: It is recommended to use `self.log('val_acc', ..., sync_dist=True)` when logging on epoch level in distributed setting to accumulate the metric across devices.\n"
-          ]
-        },
-        {
-          "name": "stdout",
-          "output_type": "stream",
-          "text": [
-            "Epoch 0:   0%|          | 0/4192 [00:00<?, ?it/s] \n",
-            "Epoch 0:   0%|          | 1/4192 [00:21<25:23:43,  0.05it/s, v_num=0, train_loss=4.230]\n",
-            "Epoch 0:   0%|          | 4/4192 [00:22<6:24:22,  0.18it/s, v_num=0, train_loss=2.540] \n",
-            ".\n",
-            ".\n",
-            ".\n",
-            "Epoch 0: 100%|\u2588\u2588\u2588\u2588\u2588\u2588\u2588\u2588\u2588\u2589| 4182/4192 [07:30<00:01,  9.28it/s, v_num=0, train_loss=0.0871]\n",
-            "Epoch 0: 100%|\u2588\u2588\u2588\u2588\u2588\u2588\u2588\u2588\u2588\u2589| 4187/4192 [07:30<00:00,  9.29it/s, v_num=0, train_loss=0.0859]\n",
-            "Epoch 0: 100%|\u2588\u2588\u2588\u2588\u2588\u2588\u2588\u2588\u2588\u2589| 4188/4192 [07:30<00:00,  9.29it/s, v_num=0, train_loss=0.112] \n",
-            "Epoch 0: 100%|\u2588\u2588\u2588\u2588\u2588\u2588\u2588\u2588\u2588\u2588| 4192/4192 [07:30<00:00,  9.30it/s, v_num=0, train_loss=0.108] \n",
-            "Validation: |          | 0/? [00:00<?, ?it/s]\u001b[A\n",
-            "\u001b[36m(RayTrainWorker pid=1150881)\u001b[0m \n",
-            "Validation:   0%|          | 0/1024 [00:00<?, ?it/s]\u001b[A\n",
-            "Validation DataLoader 0:   0%|          | 0/1024 [00:00<?, ?it/s]\u001b[A\n",
-            "Validation DataLoader 0:   0%|          | 1/1024 [00:00<00:12, 80.18it/s]\u001b[A\n",
-            "\u001b[36m(RayTrainWorker pid=1150881)\u001b[0m \n",
-            ".\n",
-            ".\n",
-            ".\n",
-            "Validation DataLoader 0: 100%|\u2588\u2588\u2588\u2588\u2588\u2588\u2588\u2588\u2588\u2589| 1022/1024 [01:41<00:00, 10.07it/s]\u001b[A\n",
-            "Validation DataLoader 0: 100%|\u2588\u2588\u2588\u2588\u2588\u2588\u2588\u2588\u2588\u2589| 1023/1024 [01:41<00:00, 10.08it/s]\u001b[A\n",
-            "\u001b[36m(RayTrainWorker pid=1150881)\u001b[0m \n",
-            "Validation DataLoader 0: 100%|\u2588\u2588\u2588\u2588\u2588\u2588\u2588\u2588\u2588\u2588| 1024/1024 [01:41<00:00, 10.09it/s]\u001b[A\n",
-            "Epoch 0: 100%|\u2588\u2588\u2588\u2588\u2588\u2588\u2588\u2588\u2588\u2588| 4192/4192 [09:35<00:00,  7.29it/s, v_num=0, train_loss=0.108]\n"
-          ]
-        },
-        {
-          "name": "stderr",
-          "output_type": "stream",
-          "text": [
-            "\u001b[36m(RayTrainWorker pid=1150881)\u001b[0m Checkpoint successfully created at: Checkpoint(filesystem=local, path=/home/dtran/protoplast_results/TorchTrainer_2025-09-24_10-36-00/TorchTrainer_43548_00000_0_2025-09-24_10-36-00/checkpoint_000000)\n",
-            "\u001b[36m(RayTrainWorker pid=1150881)\u001b[0m `Trainer.fit` stopped: `max_epochs=1` reached.\n"
-          ]
-        },
-        {
-          "name": "stdout",
-          "output_type": "stream",
-          "text": [
-            "Epoch 0: 100%|\u2588\u2588\u2588\u2588\u2588\u2588\u2588\u2588\u2588\u2588| 4192/4192 [09:35<00:00,  7.29it/s, v_num=0, train_loss=0.108]\n",
-            "Epoch 0: 100%|\u2588\u2588\u2588\u2588\u2588\u2588\u2588\u2588\u2588\u2588| 4192/4192 [09:35<00:00,  7.28it/s, v_num=0, train_loss=0.108]\n"
-          ]
-        }
-      ],
-      "source": [
-        "%%time\n",
-        "LinearClassifier_trainer = RayTrainRunner(\n",
-        "    LinearClassifier,  # replace with your own model\n",
-        "    Dcl,  # replace with your own Dataset\n",
-        "    [\"num_genes\", \"num_classes\"],  # change according to what you need for your model\n",
-        "    cell_line_metadata_cb,  # include data you need for your dataset\n",
-        ")"
-      ]
-    },
-    {
-      "cell_type": "markdown",
-      "id": "f8c2c38b",
-      "metadata": {},
-      "source": [
-        "On a machine with **1 GPU (NVIDIA GeForce RTX 3080 - 12 GiB)**, **96 CPUs**, and **125 GiB RAM**, running `LinearClassifier_trainer.train()` completed in approximately **11 minutes**."
-      ]
-    },
-    {
-      "cell_type": "code",
-      "execution_count": 4,
-      "id": "RGSE",
-      "metadata": {
-        "scrolled": true
-      },
-      "outputs": [
-        {
-          "name": "stdout",
-          "output_type": "stream",
-          "text": [
-            "Using 1 workers with {'CPU': 2} each\n",
-            "=========Length of val_split 65 length of test_split 0 length of train_split 262\n",
-            "=========Length of after dropping remainder val_split 64 length of test_split 0 length of train_split 262\n"
-          ]
-        },
-        {
-          "name": "stderr",
-          "output_type": "stream",
-          "text": [
-            "2025-09-24 10:36:00,545\tINFO tune.py:616 -- [output] This uses the legacy output and progress reporter, as Jupyter notebooks are not supported by the new engine, yet. For more information, please see https://github.com/ray-project/ray/issues/36949\n"
-          ]
-        },
-        {
-          "name": "stdout",
-          "output_type": "stream",
-          "text": [
-            "Data splitting time: 19.35 seconds\n",
-            "Spawning Ray worker and initiating distributed training\n",
-            "== Status ==\n",
-            "Current time: 2025-09-24 10:36:00 (running for 00:00:00.13)\n",
-            "Using FIFO scheduling algorithm.\n",
-            "Logical resource usage: 0/96 CPUs, 0/1 GPUs (0.0/1.0 accelerator_type:G)\n",
-            "Result logdir: /tmp/ray/session_2025-09-24_10-35-37_276608_1141478/artifacts/2025-09-24_10-36-00/TorchTrainer_2025-09-24_10-36-00/driver_artifacts\n",
-            "Number of trials: 1/1 (1 PENDING)\n",
-            "\n",
-            "\n",
-            "== Status ==\n",
-            "Current time: 2025-09-24 10:36:10 (running for 00:00:10.22)\n",
-            "Using FIFO scheduling algorithm.\n",
-            "Logical resource usage: 3.0/96 CPUs, 1.0/1 GPUs (0.0/1.0 accelerator_type:G)\n",
-            "Result logdir: /tmp/ray/session_2025-09-24_10-35-37_276608_1141478/artifacts/2025-09-24_10-36-00/TorchTrainer_2025-09-24_10-36-00/driver_artifacts\n",
-            "Number of trials: 1/1 (1 RUNNING)\n",
-            "\n",
-            "\n",
-            "== Status ==\n",
-            "Current time: 2025-09-24 10:46:14 (running for 00:10:13.83)\n",
-            "Using FIFO scheduling algorithm.\n",
-            "Logical resource usage: 3.0/96 CPUs, 1.0/1 GPUs (0.0/1.0 accelerator_type:G)\n",
-            "Result logdir: /tmp/ray/session_2025-09-24_10-35-37_276608_1141478/artifacts/2025-09-24_10-36-00/TorchTrainer_2025-09-24_10-36-00/driver_artifacts\n",
-            "Number of trials: 1/1 (1 RUNNING)\n",
-            "\n",
-            "\n"
-          ]
-        },
-        {
-          "name": "stderr",
-          "output_type": "stream",
-          "text": [
-            "2025-09-24 10:46:14,786\tINFO tune.py:1009 -- Wrote the latest version of all result files and experiment state to '/home/dtran/protoplast_results/TorchTrainer_2025-09-24_10-36-00' in 0.0064s.\n",
-            "2025-09-24 10:46:14,790\tINFO tune.py:1041 -- Total run time: 614.24 seconds (614.21 seconds for the tuning loop).\n"
-          ]
-        },
-        {
-          "name": "stdout",
-          "output_type": "stream",
-          "text": [
-            "== Status ==\n",
-            "Current time: 2025-09-24 10:46:14 (running for 00:10:14.22)\n",
-            "Using FIFO scheduling algorithm.\n",
-            "Logical resource usage: 3.0/96 CPUs, 1.0/1 GPUs (0.0/1.0 accelerator_type:G)\n",
-            "Result logdir: /tmp/ray/session_2025-09-24_10-35-37_276608_1141478/artifacts/2025-09-24_10-36-00/TorchTrainer_2025-09-24_10-36-00/driver_artifacts\n",
-            "Number of trials: 1/1 (1 TERMINATED)\n",
-            "\n",
-            "\n",
-            "CPU times: user 25.4 s, sys: 3.98 s, total: 29.3 s\n",
-            "Wall time: 10min 35s\n"
-          ]
-        }
-      ],
-      "source": [
-        "%%time\n",
-        "LinearClassifier_trainer.train(\n",
-        "    file_paths,\n",
-        "    batch_size,  # 2000\n",
-        "    test_size,  # 0.0\n",
-        "    val_size,  # 0.2\n",
-        "    thread_per_worker=thread_per_worker,  # 2\n",
-        ")\n",
-        "ray.shutdown()"
-      ]
-    },
-    {
-      "cell_type": "markdown",
-      "id": "Kclp",
-      "metadata": {},
-      "source": [
-        "## 3. SIMS: Scalable, Interpretable Models for Cell Annotation of large scale single-cell RNA-seq data\n",
-        "**SIMS** is a pipeline designed to build interpretable and accurate classifiers for identifying any target in single-cell RNA sequencing (scRNA-seq) data.  \n",
-        "- The core SIMS model is based on a **sequential transformer**, a specialized transformer architecture built for large-scale tabular datasets. \n",
-        "- SIMS provides a framework for **cell type annotation**: it trains on labeled single-cell data and predicts cell type labels for new, unlabeled cells. \n",
-        "- It leverages the **TabNet** deep learning model, which automatically selects the most informative genes for each prediction, ensuring results that are both **accurate** and **interpretable**.  \n",
-        "For implementation details and source code, see the [SIMS GitHub repository](https://github.com/braingeneers/SIMS/tree/main)."
-      ]
-    },
-    {
-      "cell_type": "markdown",
-      "id": "emfo",
-      "metadata": {},
-      "source": [
-        "### SIMS Metadata Callback\n",
-        "This callback (`sims_metadata_cb`) extracts key information from the AnnData object to configure the SIMS model.\n",
-        "- `input_dim`: the number of genes (features) in the dataset.\n",
-        "- `cell_lines`: list of unique cell line categories.\n",
-        "- `output_dim`: the number of distinct classes (cell lines) to be predicted."
-      ]
-    },
-    {
-      "cell_type": "code",
-      "execution_count": 5,
-      "id": "Hstk",
-      "metadata": {},
-      "outputs": [
-        {
-          "name": "stdout",
-          "output_type": "stream",
-          "text": [
-            "CPU times: user 32 \u03bcs, sys: 0 ns, total: 32 \u03bcs\n",
-            "Wall time: 42.7 \u03bcs\n"
-          ]
-        }
-      ],
-      "source": [
-        "%%time\n",
-        "\n",
-        "\n",
-        "def sims_metadata_cb(ad: anndata.AnnData, metadata: dict):\n",
-        "    metadata[\"num_genes\"] = ad.var.shape[0]\n",
-        "    metadata[\"input_dim\"] = metadata[\"num_genes\"]\n",
-        "    metadata[\"cell_lines\"] = ad.obs[\"cell_line\"].cat.categories.to_list()\n",
-        "    metadata[\"num_classes\"] = len(metadata[\"cell_lines\"])\n",
-        "    metadata[\"output_dim\"] = metadata[\"num_classes\"]"
-      ]
-    },
-    {
-      "cell_type": "markdown",
-      "id": "nWHF",
-      "metadata": {},
-      "source": [
-        "### Training the SIMS Classifier\n",
-        "\n",
-        "- The **SIMSClassifier** model is initialized with the dataset (`Dcl`), while essential arguments (`input_dim`, `output_dim`) are supplied through the `sims_metadata_cb` callback \n",
-        "- Training is distributed using **RayDDPStrategy**, with `find_unused_parameters=True` enabled to ensure proper handling of layers that may not be active in every forward pass\n"
-      ]
-    },
-    {
-      "cell_type": "code",
-      "execution_count": 6,
-      "id": "iLit",
-      "metadata": {
-        "scrolled": true
-      },
-      "outputs": [
-        {
-          "name": "stderr",
-          "output_type": "stream",
-          "text": [
-            "2025-09-24 10:50:12,599\tINFO worker.py:1951 -- Started a local Ray instance.\n"
-          ]
-        },
-        {
-          "name": "stdout",
-          "output_type": "stream",
-          "text": [
-            "CPU times: user 93.6 ms, sys: 213 ms, total: 307 ms\n",
-            "Wall time: 3.58 s\n",
-            "\u001b[36m(TrainTrainable pid=1164991)\u001b[0m \u2713 Applied AnnDataFileManager patch\n",
-            "\u001b[36m(TrainTrainable pid=1164991)\u001b[0m \u2713 Applied AnnDataFileManager patch\n"
-          ]
-        },
-        {
-          "name": "stderr",
-          "output_type": "stream",
-          "text": [
-            "\u001b[36m(RayTrainWorker pid=1165153)\u001b[0m Setting up process group for: env:// [rank=0, world_size=1]\n",
-            "\u001b[36m(TorchTrainer pid=1164991)\u001b[0m Started distributed worker processes: \n",
-            "\u001b[36m(TorchTrainer pid=1164991)\u001b[0m - (node_id=e9cfae65cac0d14535b39069127ce6a70b7f23ce583d528085585376, ip=192.168.1.226, pid=1165153) world_rank=0, local_rank=0, node_rank=0\n"
-          ]
-        },
-        {
-          "name": "stdout",
-          "output_type": "stream",
-          "text": [
-            "\u001b[36m(RayTrainWorker pid=1165153)\u001b[0m \u2713 Applied AnnDataFileManager patch\n",
-            "\u001b[36m(RayTrainWorker pid=1165153)\u001b[0m \u2713 Applied AnnDataFileManager patch\n",
-            "\u001b[36m(RayTrainWorker pid=1165153)\u001b[0m =========Starting the training on 0 with num threads: 2=========\n"
-          ]
-        },
-        {
-          "name": "stderr",
-          "output_type": "stream",
-          "text": [
-            "\u001b[36m(RayTrainWorker pid=1165153)\u001b[0m \ud83d\udca1 Tip: For seamless cloud uploads and versioning, try installing [litmodels](https://pypi.org/project/litmodels/) to enable LitModelCheckpoint, which syncs automatically with the Lightning model registry.\n",
-            "\u001b[36m(RayTrainWorker pid=1165153)\u001b[0m GPU available: True (cuda), used: True\n",
-            "\u001b[36m(RayTrainWorker pid=1165153)\u001b[0m TPU available: False, using: 0 TPU cores\n",
-            "\u001b[36m(RayTrainWorker pid=1165153)\u001b[0m HPU available: False, using: 0 HPUs\n",
-            "\u001b[36m(RayTrainWorker pid=1165153)\u001b[0m /mnt/hdd1/dung/protoplast-ml-example/.venv/lib/python3.11/site-packages/lightning/fabric/plugins/environments/slurm.py:204: The `srun` command is available on your system but is not used. HINT: If your intention is to run Lightning on SLURM, prepend your python command with `srun` like so: srun python /mnt/hdd1/dung/protoplast-ml-example/.venv/lib/pytho ...\n",
-            "\u001b[36m(RayTrainWorker pid=1165153)\u001b[0m You are using a CUDA device ('NVIDIA GeForce RTX 3080') that has Tensor Cores. To properly utilize them, you should set `torch.set_float32_matmul_precision('medium' | 'high')` which will trade-off precision for performance. For more details, read https://pytorch.org/docs/stable/generated/torch.set_float32_matmul_precision.html#torch.set_float32_matmul_precision\n",
-            "\u001b[36m(RayTrainWorker pid=1165153)\u001b[0m LOCAL_RANK: 0 - CUDA_VISIBLE_DEVICES: [0]\n",
-            "\u001b[36m(RayTrainWorker pid=1165153)\u001b[0m \n",
-            "\u001b[36m(RayTrainWorker pid=1165153)\u001b[0m   | Name          | Type             | Params | Mode \n",
-            "\u001b[36m(RayTrainWorker pid=1165153)\u001b[0m -----------------------------------------------------------\n",
-            "\u001b[36m(RayTrainWorker pid=1165153)\u001b[0m 0 | network       | TabNet           | 2.3 M  | train\n",
-            "\u001b[36m(RayTrainWorker pid=1165153)\u001b[0m 1 | train_metrics | MetricCollection | 0      | train\n",
-            "\u001b[36m(RayTrainWorker pid=1165153)\u001b[0m 2 | val_metrics   | MetricCollection | 0      | train\n",
-            "\u001b[36m(RayTrainWorker pid=1165153)\u001b[0m   | other params  | n/a              | 1      | n/a  \n",
-            "\u001b[36m(RayTrainWorker pid=1165153)\u001b[0m -----------------------------------------------------------\n",
-            "\u001b[36m(RayTrainWorker pid=1165153)\u001b[0m 2.3 M     Trainable params\n",
-            "\u001b[36m(RayTrainWorker pid=1165153)\u001b[0m 0         Non-trainable params\n",
-            "\u001b[36m(RayTrainWorker pid=1165153)\u001b[0m 2.3 M     Total params\n",
-            "\u001b[36m(RayTrainWorker pid=1165153)\u001b[0m 9.054     Total estimated model params size (MB)\n",
-            "\u001b[36m(RayTrainWorker pid=1165153)\u001b[0m 119       Modules in train mode\n",
-            "\u001b[36m(RayTrainWorker pid=1165153)\u001b[0m 0         Modules in eval mode\n",
-            "\u001b[36m(RayTrainWorker pid=1165153)\u001b[0m /mnt/hdd1/dung/protoplast-ml-example/.venv/lib/python3.11/site-packages/torch/distributed/distributed_c10d.py:4807: UserWarning: No device id is provided via `init_process_group` or `barrier `. Using the current device set by the user. \n",
-            "\u001b[36m(RayTrainWorker pid=1165153)\u001b[0m   warnings.warn(  # warn only once\n",
-            "\u001b[36m(RayTrainWorker pid=1165153)\u001b[0m /mnt/hdd1/dung/protoplast-ml-example/.venv/lib/python3.11/site-packages/lightning/pytorch/utilities/data.py:123: Your `IterableDataset` has `__len__` defined. In combination with multi-process data loading (when num_workers > 1), `__len__` could be inaccurate if each worker is not configured independently to avoid having duplicate data.\n"
-          ]
-        },
-        {
-          "name": "stdout",
-          "output_type": "stream",
-          "text": [
-            "Sanity Checking: |          | 0/? [00:00<?, ?it/s]\n"
-          ]
-        },
-        {
-          "name": "stderr",
-          "output_type": "stream",
-          "text": [
-            "\u001b[36m(RayTrainWorker pid=1165153)\u001b[0m /mnt/hdd1/dung/protoplast-ml-example/submodules/protoplast/src/protoplast/scrna/anndata/torch_dataloader.py:107: UserWarning: Sparse CSR tensor support is in beta state. If you miss a functionality in the sparse tensor support, please submit a feature request to https://github.com/pytorch/pytorch/issues. (Triggered internally at /pytorch/aten/src/ATen/SparseCsrTensorImpl.cpp:53.)\n",
-            "\u001b[36m(RayTrainWorker pid=1165153)\u001b[0m   return torch.sparse_csr_tensor(\n",
-            "\u001b[36m(RayTrainWorker pid=1165153)\u001b[0m /mnt/hdd1/dung/protoplast-ml-example/.venv/lib/python3.11/site-packages/torch/multiprocessing/reductions.py:473: UserWarning: Sparse CSR tensor support is in beta state. If you miss a functionality in the sparse tensor support, please submit a feature request to https://github.com/pytorch/pytorch/issues. (Triggered internally at /pytorch/aten/src/ATen/SparseCsrTensorImpl.cpp:53.)\n",
-            "\u001b[36m(RayTrainWorker pid=1165153)\u001b[0m   return torch.sparse_compressed_tensor(\n"
-          ]
-        },
-        {
-          "name": "stdout",
-          "output_type": "stream",
-          "text": [
-            "Sanity Checking DataLoader 0:   0%|          | 0/2 [00:00<?, ?it/s]\n"
-          ]
-        },
-        {
-          "name": "stderr",
-          "output_type": "stream",
-          "text": [
-            "\u001b[36m(RayTrainWorker pid=1165153)\u001b[0m /mnt/hdd1/dung/protoplast-ml-example/submodules/protoplast/src/protoplast/scrna/anndata/torch_dataloader.py:107: UserWarning: Sparse CSR tensor support is in beta state. If you miss a functionality in the sparse tensor support, please submit a feature request to https://github.com/pytorch/pytorch/issues. (Triggered internally at /pytorch/aten/src/ATen/SparseCsrTensorImpl.cpp:53.)\n",
-            "\u001b[36m(RayTrainWorker pid=1165153)\u001b[0m   return torch.sparse_csr_tensor(\n"
-          ]
-        },
-        {
-          "name": "stdout",
-          "output_type": "stream",
-          "text": [
-            "Sanity Checking DataLoader 0:  50%|\u2588\u2588\u2588\u2588\u2588     | 1/2 [00:01<00:01,  0.89it/s]\n",
-            "Sanity Checking DataLoader 0: 100%|\u2588\u2588\u2588\u2588\u2588\u2588\u2588\u2588\u2588\u2588| 2/2 [00:01<00:00,  1.67it/s]\n"
-          ]
-        },
-        {
-          "name": "stderr",
-          "output_type": "stream",
-          "text": [
-            "\u001b[36m(RayTrainWorker pid=1165153)\u001b[0m /mnt/hdd1/dung/protoplast-ml-example/.venv/lib/python3.11/site-packages/lightning/pytorch/trainer/connectors/logger_connector/result.py:434: It is recommended to use `self.log('val/loss', ..., sync_dist=True)` when logging on epoch level in distributed setting to accumulate the metric across devices.\n",
-            "\u001b[36m(RayTrainWorker pid=1165153)\u001b[0m /mnt/hdd1/dung/protoplast-ml-example/.venv/lib/python3.11/site-packages/lightning/pytorch/trainer/connectors/logger_connector/result.py:434: It is recommended to use `self.log('val/f1', ..., sync_dist=True)` when logging on epoch level in distributed setting to accumulate the metric across devices.\n",
-            "\u001b[36m(RayTrainWorker pid=1165153)\u001b[0m /mnt/hdd1/dung/protoplast-ml-example/.venv/lib/python3.11/site-packages/lightning/pytorch/trainer/connectors/logger_connector/result.py:434: It is recommended to use `self.log('val/macro_acc', ..., sync_dist=True)` when logging on epoch level in distributed setting to accumulate the metric across devices.\n",
-            "\u001b[36m(RayTrainWorker pid=1165153)\u001b[0m /mnt/hdd1/dung/protoplast-ml-example/.venv/lib/python3.11/site-packages/lightning/pytorch/trainer/connectors/logger_connector/result.py:434: It is recommended to use `self.log('val/micro_acc', ..., sync_dist=True)` when logging on epoch level in distributed setting to accumulate the metric across devices.\n",
-            "\u001b[36m(RayTrainWorker pid=1165153)\u001b[0m /mnt/hdd1/dung/protoplast-ml-example/.venv/lib/python3.11/site-packages/lightning/pytorch/trainer/connectors/logger_connector/result.py:434: It is recommended to use `self.log('val/precision', ..., sync_dist=True)` when logging on epoch level in distributed setting to accumulate the metric across devices.\n",
-            "\u001b[36m(RayTrainWorker pid=1165153)\u001b[0m /mnt/hdd1/dung/protoplast-ml-example/.venv/lib/python3.11/site-packages/lightning/pytorch/trainer/connectors/logger_connector/result.py:434: It is recommended to use `self.log('val/recall', ..., sync_dist=True)` when logging on epoch level in distributed setting to accumulate the metric across devices.\n",
-            "\u001b[36m(RayTrainWorker pid=1165153)\u001b[0m /mnt/hdd1/dung/protoplast-ml-example/.venv/lib/python3.11/site-packages/lightning/pytorch/trainer/connectors/logger_connector/result.py:434: It is recommended to use `self.log('val/specificity', ..., sync_dist=True)` when logging on epoch level in distributed setting to accumulate the metric across devices.\n",
-            "\u001b[36m(RayTrainWorker pid=1165153)\u001b[0m /mnt/hdd1/dung/protoplast-ml-example/.venv/lib/python3.11/site-packages/lightning/pytorch/trainer/connectors/logger_connector/result.py:434: It is recommended to use `self.log('val/weighted_acc', ..., sync_dist=True)` when logging on epoch level in distributed setting to accumulate the metric across devices.\n"
-          ]
-        },
-        {
-          "name": "stdout",
-          "output_type": "stream",
-          "text": [
-            "Epoch 0:   0%|          | 0/4192 [00:00<?, ?it/s]                          \n",
-            "Epoch 0:   0%|          | 1/4192 [00:24<28:07:32,  0.04it/s, v_num=0, train/loss_step=4.640]\n",
-            "Epoch 0:   0%|          | 2/4192 [00:24<14:08:17,  0.08it/s, v_num=0, train/loss_step=4.180]\n",
-            "Epoch 0:   0%|          | 3/4192 [00:24<9:28:04,  0.12it/s, v_num=0, train/loss_step=3.940] \n",
-            ".\n",
-            ".\n",
-            ".\n",
-            "Epoch 0: 100%|\u2588\u2588\u2588\u2588\u2588\u2588\u2588\u2588\u2588\u2589| 4189/4192 [12:34<00:00,  5.55it/s, v_num=0, train/loss_step=0.400]\n",
-            "Epoch 0: 100%|\u2588\u2588\u2588\u2588\u2588\u2588\u2588\u2588\u2588\u2589| 4190/4192 [12:35<00:00,  5.55it/s, v_num=0, train/loss_step=0.394]\n",
-            "Epoch 0: 100%|\u2588\u2588\u2588\u2588\u2588\u2588\u2588\u2588\u2588\u2589| 4191/4192 [12:35<00:00,  5.55it/s, v_num=0, train/loss_step=0.362]\n",
-            "Epoch 0: 100%|\u2588\u2588\u2588\u2588\u2588\u2588\u2588\u2588\u2588\u2588| 4192/4192 [12:35<00:00,  5.55it/s, v_num=0, train/loss_step=0.495]\n",
-            "Validation: |          | 0/? [00:00<?, ?it/s]\u001b[A\n",
-            "\u001b[36m(RayTrainWorker pid=1165153)\u001b[0m \n",
-            "Validation:   0%|          | 0/1024 [00:00<?, ?it/s]\u001b[A\n",
-            "Validation DataLoader 0:   0%|          | 0/1024 [00:00<?, ?it/s]\u001b[A\n",
-            "\u001b[36m(RayTrainWorker pid=1165153)\u001b[0m \n",
-            "Validation DataLoader 0:   0%|          | 1/1024 [00:00<00:47, 21.70it/s]\u001b[A\n",
-            "Validation DataLoader 0:   0%|          | 2/1024 [00:00<00:50, 20.31it/s]\u001b[A\n",
-            "\u001b[36m(RayTrainWorker pid=1165153)\u001b[0m \n",
-            ".\n",
-            ".\n",
-            ".\n",
-            "Validation DataLoader 0: 100%|\u2588\u2588\u2588\u2588\u2588\u2588\u2588\u2588\u2588\u2589| 1023/1024 [01:55<00:00,  8.83it/s]\u001b[A\n",
-            "Validation DataLoader 0: 100%|\u2588\u2588\u2588\u2588\u2588\u2588\u2588\u2588\u2588\u2588| 1024/1024 [01:55<00:00,  8.84it/s]\u001b[A\n",
-            "\u001b[36m(RayTrainWorker pid=1165153)\u001b[0m \n",
-            "Epoch 0: 100%|\u2588\u2588\u2588\u2588\u2588\u2588\u2588\u2588\u2588\u2588| 4192/4192 [14:56<00:00,  4.68it/s, v_num=0, train/loss_step=0.495, val/loss=0.583, val/f1=0.830, val/macro_acc=0.827, val/micro_acc=0.929, val/precision=0.837, val/recall=0.827, val/specificity=0.999, val/weighted_acc=0.929]\n"
-          ]
-        },
-        {
-          "name": "stderr",
-          "output_type": "stream",
-          "text": [
-            "\u001b[36m(RayTrainWorker pid=1165153)\u001b[0m /mnt/hdd1/dung/protoplast-ml-example/.venv/lib/python3.11/site-packages/lightning/pytorch/trainer/connectors/logger_connector/result.py:434: It is recommended to use `self.log('train/loss', ..., sync_dist=True)` when logging on epoch level in distributed setting to accumulate the metric across devices.\n",
-            "\u001b[36m(RayTrainWorker pid=1165153)\u001b[0m Checkpoint successfully created at: Checkpoint(filesystem=local, path=/home/dtran/protoplast_results/TorchTrainer_2025-09-24_10-50-35/TorchTrainer_4d208_00000_0_2025-09-24_10-50-35/checkpoint_000000)\n",
-            "\u001b[36m(RayTrainWorker pid=1165153)\u001b[0m /mnt/hdd1/dung/protoplast-ml-example/.venv/lib/python3.11/site-packages/lightning/pytorch/trainer/connectors/logger_connector/result.py:434: It is recommended to use `self.log('train/f1', ..., sync_dist=True)` when logging on epoch level in distributed setting to accumulate the metric across devices.\n",
-            "\u001b[36m(RayTrainWorker pid=1165153)\u001b[0m /mnt/hdd1/dung/protoplast-ml-example/.venv/lib/python3.11/site-packages/lightning/pytorch/trainer/connectors/logger_connector/result.py:434: It is recommended to use `self.log('train/macro_acc', ..., sync_dist=True)` when logging on epoch level in distributed setting to accumulate the metric across devices.\n",
-            "\u001b[36m(RayTrainWorker pid=1165153)\u001b[0m /mnt/hdd1/dung/protoplast-ml-example/.venv/lib/python3.11/site-packages/lightning/pytorch/trainer/connectors/logger_connector/result.py:434: It is recommended to use `self.log('train/micro_acc', ..., sync_dist=True)` when logging on epoch level in distributed setting to accumulate the metric across devices.\n",
-            "\u001b[36m(RayTrainWorker pid=1165153)\u001b[0m /mnt/hdd1/dung/protoplast-ml-example/.venv/lib/python3.11/site-packages/lightning/pytorch/trainer/connectors/logger_connector/result.py:434: It is recommended to use `self.log('train/precision', ..., sync_dist=True)` when logging on epoch level in distributed setting to accumulate the metric across devices.\n",
-            "\u001b[36m(RayTrainWorker pid=1165153)\u001b[0m /mnt/hdd1/dung/protoplast-ml-example/.venv/lib/python3.11/site-packages/lightning/pytorch/trainer/connectors/logger_connector/result.py:434: It is recommended to use `self.log('train/recall', ..., sync_dist=True)` when logging on epoch level in distributed setting to accumulate the metric across devices.\n",
-            "\u001b[36m(RayTrainWorker pid=1165153)\u001b[0m /mnt/hdd1/dung/protoplast-ml-example/.venv/lib/python3.11/site-packages/lightning/pytorch/trainer/connectors/logger_connector/result.py:434: It is recommended to use `self.log('train/specificity', ..., sync_dist=True)` when logging on epoch level in distributed setting to accumulate the metric across devices.\n",
-            "\u001b[36m(RayTrainWorker pid=1165153)\u001b[0m /mnt/hdd1/dung/protoplast-ml-example/.venv/lib/python3.11/site-packages/lightning/pytorch/trainer/connectors/logger_connector/result.py:434: It is recommended to use `self.log('train/weighted_acc', ..., sync_dist=True)` when logging on epoch level in distributed setting to accumulate the metric across devices.\n",
-            "\u001b[36m(RayTrainWorker pid=1165153)\u001b[0m `Trainer.fit` stopped: `max_epochs=1` reached.\n"
-          ]
-        },
-        {
-          "name": "stdout",
-          "output_type": "stream",
-          "text": [
-            "Epoch 0: 100%|\u2588\u2588\u2588\u2588\u2588\u2588\u2588\u2588\u2588\u2588| 4192/4192 [14:56<00:00,  4.67it/s, v_num=0, train/loss_step=0.495, val/loss=0.583, val/f1=0.830, val/macro_acc=0.827, val/micro_acc=0.929, val/precision=0.837, val/recall=0.827, val/specificity=0.999, val/weighted_acc=0.929, train/loss_epoch=0.489]\n",
-            "Epoch 0: 100%|\u2588\u2588\u2588\u2588\u2588\u2588\u2588\u2588\u2588\u2588| 4192/4192 [14:56<00:00,  4.67it/s, v_num=0, train/loss_step=0.495, val/loss=0.583, val/f1=0.830, val/macro_acc=0.827, val/micro_acc=0.929, val/precision=0.837, val/recall=0.827, val/specificity=0.999, val/weighted_acc=0.929, train/loss_epoch=0.489]\n"
-          ]
-        }
-      ],
-      "source": [
-        "%%time\n",
-        "sims_trainer = RayTrainRunner(\n",
-        "    SIMSClassifier,\n",
-        "    Dcl,\n",
-        "    [\"input_dim\", \"output_dim\"],  # maps to SIMSClassifier(input_dim, output_dim)\n",
-        "    sims_metadata_cb,\n",
-        "    ray_trainer_strategy=RayDDPStrategy(find_unused_parameters=True),\n",
-        ")"
-      ]
-    },
-    {
-      "cell_type": "markdown",
-      "id": "bb1d58ff",
-      "metadata": {},
-      "source": [
-        "On a machine with **1 GPU (NVIDIA GeForce RTX 3080 - 12 GiB)**, **96 CPUs**, and **125 GiB RAM**, running `sims_trainer.train()` completed in about **17 minutes**."
-      ]
-    },
-    {
-      "cell_type": "code",
-      "execution_count": 7,
-      "id": "ZHCJ",
-      "metadata": {
-        "scrolled": true
-      },
-      "outputs": [
-        {
-          "name": "stdout",
-          "output_type": "stream",
-          "text": [
-            "Using 1 workers with {'CPU': 2} each\n",
-            "=========Length of val_split 65 length of test_split 0 length of train_split 262\n",
-            "=========Length of after dropping remainder val_split 64 length of test_split 0 length of train_split 262\n"
-          ]
-        },
-        {
-          "name": "stderr",
-          "output_type": "stream",
-          "text": [
-            "2025-09-24 10:50:35,977\tINFO tune.py:616 -- [output] This uses the legacy output and progress reporter, as Jupyter notebooks are not supported by the new engine, yet. For more information, please see https://github.com/ray-project/ray/issues/36949\n"
-          ]
-        },
-        {
-          "name": "stdout",
-          "output_type": "stream",
-          "text": [
-            "Data splitting time: 19.49 seconds\n",
-            "Spawning Ray worker and initiating distributed training\n",
-            "== Status ==\n",
-            "Current time: 2025-09-24 10:50:36 (running for 00:00:00.12)\n",
-            "Using FIFO scheduling algorithm.\n",
-            "Logical resource usage: 0/96 CPUs, 0/1 GPUs (0.0/1.0 accelerator_type:G)\n",
-            "Result logdir: /tmp/ray/session_2025-09-24_10-50-10_126896_1141478/artifacts/2025-09-24_10-50-35/TorchTrainer_2025-09-24_10-50-35/driver_artifacts\n",
-            "Number of trials: 1/1 (1 PENDING)\n",
-            "\n",
-            "\n",
-            "== Status ==\n",
-            "Current time: 2025-09-24 10:50:46 (running for 00:00:10.27)\n",
-            "Using FIFO scheduling algorithm.\n",
-            "Logical resource usage: 3.0/96 CPUs, 1.0/1 GPUs (0.0/1.0 accelerator_type:G)\n",
-            "Result logdir: /tmp/ray/session_2025-09-24_10-50-10_126896_1141478/artifacts/2025-09-24_10-50-35/TorchTrainer_2025-09-24_10-50-35/driver_artifacts\n",
-            "Number of trials: 1/1 (1 RUNNING)\n",
-            "\n",
-            "\n",
-            "== Status ==\n",
-            "Current time: 2025-09-24 11:06:57 (running for 00:16:21.19)\n",
-            "Using FIFO scheduling algorithm.\n",
-            "Logical resource usage: 3.0/96 CPUs, 1.0/1 GPUs (0.0/1.0 accelerator_type:G)\n",
-            "Result logdir: /tmp/ray/session_2025-09-24_10-50-10_126896_1141478/artifacts/2025-09-24_10-50-35/TorchTrainer_2025-09-24_10-50-35/driver_artifacts\n",
-            "Number of trials: 1/1 (1 RUNNING)\n",
-            "\n",
-            "\n"
-          ]
-        },
-        {
-          "name": "stderr",
-          "output_type": "stream",
-          "text": [
-            "2025-09-24 11:07:00,414\tINFO tune.py:1009 -- Wrote the latest version of all result files and experiment state to '/home/dtran/protoplast_results/TorchTrainer_2025-09-24_10-50-35' in 0.0150s.\n",
-            "2025-09-24 11:07:00,419\tINFO tune.py:1041 -- Total run time: 984.44 seconds (984.41 seconds for the tuning loop).\n"
-          ]
-        },
-        {
-          "name": "stdout",
-          "output_type": "stream",
-          "text": [
-            "== Status ==\n",
-            "Current time: 2025-09-24 11:07:00 (running for 00:16:24.43)\n",
-            "Using FIFO scheduling algorithm.\n",
-            "Logical resource usage: 3.0/96 CPUs, 1.0/1 GPUs (0.0/1.0 accelerator_type:G)\n",
-            "Result logdir: /tmp/ray/session_2025-09-24_10-50-10_126896_1141478/artifacts/2025-09-24_10-50-35/TorchTrainer_2025-09-24_10-50-35/driver_artifacts\n",
-            "Number of trials: 1/1 (1 TERMINATED)\n",
-            "\n",
-            "\n",
-            "CPU times: user 32.9 s, sys: 5.4 s, total: 38.3 s\n",
-            "Wall time: 16min 45s\n"
-          ]
-        }
-      ],
-      "source": [
-        "%%time\n",
-        "sims_trainer.train(\n",
-        "    file_paths,\n",
-        "    batch_size,  # 2000\n",
-        "    test_size,  # 0.0\n",
-        "    val_size,  # 0.2\n",
-        "    thread_per_worker=thread_per_worker,\n",
-        ")\n",
-        "ray.shutdown()"
-      ]
-    },
-    {
-      "cell_type": "markdown",
-      "id": "ROlb",
-      "metadata": {},
-      "source": [
-        "## 4. Autoencoder\n",
-        "- An **autoencoder** is an unsupervised neural network consisting of three main components:  \n",
-        "  - **Encoder**: compresses the input into a lower-dimensional representation.  \n",
-        "  - **Bottleneck**: stores the compressed features.  \n",
-        "  - **Decoder**: reconstructs the input from the bottleneck representation.  \n",
-        "- In this setup, separate encoders process **gene** and **protein** data. Their outputs are concatenated, passed through an additional encoder to form the bottleneck, and then decoded back to the original input.  \n",
-        "- Since **Tahoe-100M** does not include protein data, the protein input is set to `0`, and the source code was adapted to ensure compatibility with datasets lacking protein features.\n",
-        "- For testing purposes, we temporarily set mid = 128, which reduces the hidden layer size and simplifies the model architecture. For implementation details, see the [CITE-seq autoencoder source code](https://github.com/naity/citeseq_autoencoder/blob/main/autoencoder_citeseq_saturn.ipynb)."
-      ]
-    },
-    {
-      "cell_type": "code",
-      "execution_count": 8,
-      "id": "1fed382e-57ce-4209-8d44-9304f686aa5d",
-      "metadata": {},
-      "outputs": [
-        {
-          "name": "stdout",
-          "output_type": "stream",
-          "text": [
-            "CPU times: user 433 \u03bcs, sys: 0 ns, total: 433 \u03bcs\n",
-            "Wall time: 446 \u03bcs\n"
-          ]
-        }
-      ],
-      "source": [
-        "%%time\n",
-        "# group linear, batchnorm, and dropout layers. This module was from citeseq_autoencoder notebook\n",
-        "import lightning.pytorch as pl\n",
-        "import torch\n",
-        "import torch.nn.functional as F\n",
-        "from torch import nn, optim\n",
-        "\n",
-        "\n",
-        "class LinBnDrop(nn.Sequential):\n",
-        "    \"\"\"Module grouping `BatchNorm1d`, `Dropout` and `Linear` layers, adapted from fastai.\"\"\"\n",
-        "\n",
-        "    def __init__(self, n_in, n_out, bn=True, p=0.0, act=None, lin_first=True):\n",
-        "        layers = [nn.BatchNorm1d(n_out if lin_first else n_in)] if bn else []\n",
-        "        if p != 0:\n",
-        "            layers.append(nn.Dropout(p))\n",
-        "        lin = [nn.Linear(n_in, n_out, bias=not bn)]\n",
-        "        if act is not None:\n",
-        "            lin.append(act)\n",
-        "        layers = lin + layers if lin_first else layers + lin\n",
-        "        super().__init__(*layers)"
-      ]
-    },
-    {
-      "cell_type": "markdown",
-      "id": "a34de981-1801-4843-bb78-094f5f69435d",
-      "metadata": {},
-      "source": [
-        "We implement an encoder that processes RNA features through a two-layer MLP (`nfeatures_rna` \u2192 `mid=128` \u2192 `hidden_rna`, with `mid=2` set for testing). The source code is from [CITE-seq autoencoder source code](https://github.com/naity/citeseq_autoencoder/blob/main/autoencoder_citeseq_saturn.ipynb)."
-      ]
-    },
-    {
-      "cell_type": "code",
-      "execution_count": 9,
-      "id": "5caadfbd-c2f0-423e-9a96-f9b6dd59baab",
-      "metadata": {},
-      "outputs": [
-        {
-          "name": "stdout",
-          "output_type": "stream",
-          "text": [
-            "CPU times: user 116 \u03bcs, sys: 0 ns, total: 116 \u03bcs\n",
-            "Wall time: 128 \u03bcs\n"
-          ]
-        }
-      ],
-      "source": [
-        "%%time\n",
-        "\n",
-        "\n",
-        "class Encoder(nn.Module):\n",
-        "    \"\"\"Encoder for CITE-seq data\"\"\"\n",
-        "\n",
-        "    def __init__(\n",
-        "        self, nfeatures_rna: int, nfeatures_pro: int, hidden_rna: int, hidden_pro: int, latent_dim: int, p: float = 0\n",
-        "    ):\n",
-        "        super().__init__()\n",
-        "        self.nfeatures_rna = nfeatures_rna\n",
-        "        self.nfeatures_pro = nfeatures_pro\n",
-        "\n",
-        "        if nfeatures_rna > 0:\n",
-        "            mid = 128  # 128 is for testing the code\n",
-        "            self.encoder_rna = nn.Sequential(\n",
-        "                LinBnDrop(nfeatures_rna, mid, p=p, act=nn.LeakyReLU()),\n",
-        "                LinBnDrop(mid, hidden_rna, act=nn.LeakyReLU()),\n",
-        "            )\n",
-        "\n",
-        "        if nfeatures_pro > 0:\n",
-        "            self.encoder_protein = LinBnDrop(nfeatures_pro, hidden_pro, p=p, act=nn.LeakyReLU())\n",
-        "\n",
-        "        # make sure hidden_rna and hidden_pro are set correctly\n",
-        "        hidden_rna = 0 if nfeatures_rna == 0 else hidden_rna\n",
-        "        hidden_pro = 0 if nfeatures_pro == 0 else hidden_pro\n",
-        "\n",
-        "        hidden_dim = hidden_rna + hidden_pro\n",
-        "\n",
-        "        self.encoder = LinBnDrop(hidden_dim, latent_dim, act=nn.LeakyReLU())\n",
-        "\n",
-        "    def forward(self, x):\n",
-        "        if self.nfeatures_rna > 0 and self.nfeatures_pro > 0:\n",
-        "            x_rna = self.encoder_rna(x[:, : self.nfeatures_rna])\n",
-        "            x_pro = self.encoder_protein(x[:, self.nfeatures_rna :])\n",
-        "            x = torch.cat([x_rna, x_pro], 1)\n",
-        "        elif self.nfeatures_rna > 0 and self.nfeatures_pro == 0:\n",
-        "            x = self.encoder_rna(x)\n",
-        "        elif self.nfeatures_rna == 0 and self.nfeatures_pro > 0:\n",
-        "            x = self.encoder_protein(x)\n",
-        "        return self.encoder(x)"
-      ]
-    },
-    {
-      "cell_type": "markdown",
-      "id": "503455d4-dc3e-43e8-85cc-9f60377fa8a7",
-      "metadata": {},
-      "source": [
-        "We implement a decoder that maps the latent vector to the RNA feature space by first expanding it to `hidden_rna`, passing it through a small intermediate layer (`mid_out` = `128`, used for testing), and finally projecting it to the RNA output dimension. The source code is from [CITE-seq autoencoder source code](https://github.com/naity/citeseq_autoencoder/blob/main/autoencoder_citeseq_saturn.ipynb)."
-      ]
-    },
-    {
-      "cell_type": "code",
-      "execution_count": 10,
-      "id": "fc2d627b-fe57-4419-926f-14b371ad083c",
-      "metadata": {},
-      "outputs": [
-        {
-          "name": "stdout",
-          "output_type": "stream",
-          "text": [
-            "CPU times: user 69 \u03bcs, sys: 0 ns, total: 69 \u03bcs\n",
-            "Wall time: 80.3 \u03bcs\n"
-          ]
-        }
-      ],
-      "source": [
-        "%%time\n",
-        "\n",
-        "\n",
-        "class Decoder(nn.Module):\n",
-        "    \"\"\"Decoder for CITE-seq data\"\"\"\n",
-        "\n",
-        "    def __init__(self, nfeatures_rna: int, nfeatures_pro: int, hidden_rna: int, hidden_pro: int, latent_dim: int):\n",
-        "        super().__init__()\n",
-        "        # make sure hidden_rna and hidden_pro are set correctly\n",
-        "        hidden_rna = 0 if nfeatures_rna == 0 else hidden_rna\n",
-        "        hidden_pro = 0 if nfeatures_pro == 0 else hidden_pro\n",
-        "\n",
-        "        hidden_dim = hidden_rna + hidden_pro\n",
-        "        out_dim = nfeatures_rna + nfeatures_pro\n",
-        "        mid_out = 128  # 128 is for testing the code\n",
-        "\n",
-        "        self.decoder = nn.Sequential(\n",
-        "            LinBnDrop(latent_dim, hidden_dim, act=nn.LeakyReLU()),\n",
-        "            LinBnDrop(hidden_dim, mid_out, act=nn.LeakyReLU()),\n",
-        "            LinBnDrop(mid_out, out_dim, bn=False),\n",
-        "        )\n",
-        "\n",
-        "    def forward(self, x):\n",
-        "        return self.decoder(x)"
-      ]
-    },
-    {
-      "cell_type": "markdown",
-      "id": "be00e509-8a29-4026-92a5-fa3a3213ff1f",
-      "metadata": {},
-      "source": [
-        "The encoder and decoder are assembled into an autoencoder, which is defined as a PyTorch Lightning Module to simplify the training process. The source code is from [CITE-seq autoencoder source code](https://github.com/naity/citeseq_autoencoder/blob/main/autoencoder_citeseq_saturn.ipynb)"
-      ]
-    },
-    {
-      "cell_type": "code",
-      "execution_count": 11,
-      "id": "78797222-d09b-4456-97aa-565cebf017ac",
-      "metadata": {},
-      "outputs": [
-        {
-          "name": "stdout",
-          "output_type": "stream",
-          "text": [
-            "CPU times: user 288 \u03bcs, sys: 0 ns, total: 288 \u03bcs\n",
-            "Wall time: 300 \u03bcs\n"
-          ]
-        }
-      ],
-      "source": [
-        "%%time\n",
-        "\n",
-        "\n",
-        "class CiteAutoencoder(pl.LightningModule):\n",
-        "    def __init__(\n",
-        "        self,\n",
-        "        nfeatures_rna: int,\n",
-        "        nfeatures_pro: int,\n",
-        "        hidden_rna: int,\n",
-        "        hidden_pro: int,\n",
-        "        latent_dim: int,\n",
-        "        p: float = 0,\n",
-        "        lr: float = 0.1,\n",
-        "    ):\n",
-        "        \"\"\"Autoencoder for citeseq data\"\"\"\n",
-        "        super().__init__()\n",
-        "\n",
-        "        # save hyperparameters\n",
-        "        self.save_hyperparameters()\n",
-        "\n",
-        "        self.encoder = Encoder(nfeatures_rna, nfeatures_pro, hidden_rna, hidden_pro, latent_dim, p)\n",
-        "        self.decoder = Decoder(nfeatures_rna, nfeatures_pro, hidden_rna, hidden_pro, latent_dim)\n",
-        "\n",
-        "        # example input array for visualizing network graph\n",
-        "        self.example_input_array = torch.zeros(256, nfeatures_rna + nfeatures_pro)\n",
-        "\n",
-        "    def forward(self, x):\n",
-        "        # extract latent embeddings\n",
-        "        z = self.encoder(x)\n",
-        "        return z\n",
-        "\n",
-        "    def configure_optimizers(self):\n",
-        "        optimizer = optim.Adam(self.parameters(), lr=self.hparams.lr)\n",
-        "        scheduler = optim.lr_scheduler.ReduceLROnPlateau(optimizer)\n",
-        "        return {\"optimizer\": optimizer, \"lr_scheduler\": scheduler, \"monitor\": \"val_loss\"}\n",
-        "\n",
-        "    def _get_reconstruction_loss(self, batch):\n",
-        "        \"\"\"Calculate MSE loss for a given batch.\"\"\"\n",
-        "        x, _ = batch\n",
-        "        z = self.encoder(x)\n",
-        "        x_hat = self.decoder(z)\n",
-        "        # MSE loss\n",
-        "        loss = F.mse_loss(x_hat, x)\n",
-        "        return loss\n",
-        "\n",
-        "    def training_step(self, batch, batch_idx):\n",
-        "        loss = self._get_reconstruction_loss(batch)\n",
-        "        self.log(\"train_loss\", loss)\n",
-        "        return loss\n",
-        "\n",
-        "    def validation_step(self, batch, batch_idx):\n",
-        "        loss = self._get_reconstruction_loss(batch)\n",
-        "        self.log(\"val_loss\", loss)"
-      ]
-    },
-    {
-      "cell_type": "markdown",
-      "id": "qnkX",
-      "metadata": {},
-      "source": [
-        "### Autoencoder Metadata Callback\n",
-        "- The `ae_metadata_cb` function extends `cell_line_metadata_cb` and configures the metadata required for training the autoencoder. It sets up cell line information, defines feature counts, and specifies key model hyperparameters such as hidden dimensions, latent space size, dropout, and learning rate\n",
-        "\n",
-        "**Note (for testing):**  \n",
-        "In `ae_metadata_cb`, both the hidden RNA dimension (`hidden_rna=128`) and the latent dimension (`latent_dim=16`) are intentionally set to very small values. This configuration is used for quick testing and validation, not for full-scale training."
-      ]
-    },
-    {
-      "cell_type": "code",
-      "execution_count": 13,
-      "id": "TqIu",
-      "metadata": {},
-      "outputs": [
-        {
-          "name": "stdout",
-          "output_type": "stream",
-          "text": [
-            "CPU times: user 16 \u03bcs, sys: 0 ns, total: 16 \u03bcs\n",
-            "Wall time: 25.7 \u03bcs\n"
-          ]
-        }
-      ],
-      "source": [
-        "%%time\n",
-        "\n",
-        "\n",
-        "def ae_metadata_cb(ad, metadata):\n",
-        "    cell_line_metadata_cb(ad, metadata)\n",
-        "    metadata[\"cell_lines\"] = np.sort(np.unique(ad.obs[\"cell_line\"].to_numpy()))\n",
-        "    metadata[\"nfeatures_rna\"] = metadata[\"num_genes\"]\n",
-        "    metadata[\"nfeatures_pro\"] = 0\n",
-        "    metadata[\"hidden_rna\"] = 128\n",
-        "    metadata[\"hidden_pro\"] = 0\n",
-        "    metadata[\"latent_dim\"] = 16\n",
-        "    metadata[\"p\"] = 0.1\n",
-        "    metadata[\"lr\"] = 1e-3"
-      ]
-    },
-    {
-      "cell_type": "markdown",
-      "id": "Vxnm",
-      "metadata": {},
-      "source": [
-        "### Training the CiteAutoencoder model\n",
-        "- The dataset (`Dcl`) is provided along with key model parameters such as RNA/protein feature counts, hidden layer sizes, latent dimension, dropout p, and learning rate lr, all supplied through the `ae_metadata_cb` callback."
-      ]
-    },
-    {
-      "cell_type": "code",
-      "execution_count": 14,
-      "id": "DnEU",
-      "metadata": {
-        "scrolled": true
-      },
-      "outputs": [
-        {
-          "name": "stderr",
-          "output_type": "stream",
-          "text": [
-            "2025-09-24 11:10:06,808\tINFO worker.py:1951 -- Started a local Ray instance.\n"
-          ]
-        },
-        {
-          "name": "stdout",
-          "output_type": "stream",
-          "text": [
-            "CPU times: user 98.4 ms, sys: 249 ms, total: 347 ms\n",
-            "Wall time: 3.66 s\n",
-            "\u001b[36m(TrainTrainable pid=1179158)\u001b[0m \u2713 Applied AnnDataFileManager patch\n",
-            "\u001b[36m(TrainTrainable pid=1179158)\u001b[0m \u2713 Applied AnnDataFileManager patch\n"
-          ]
-        },
-        {
-          "name": "stderr",
-          "output_type": "stream",
-          "text": [
-            "\u001b[36m(RayTrainWorker pid=1179295)\u001b[0m Setting up process group for: env:// [rank=0, world_size=1]\n",
-            "\u001b[36m(TorchTrainer pid=1179158)\u001b[0m Started distributed worker processes: \n",
-            "\u001b[36m(TorchTrainer pid=1179158)\u001b[0m - (node_id=f80fa4e223aee996e709cca29ff756652a6e60f007fef994b41ebd7e, ip=192.168.1.226, pid=1179295) world_rank=0, local_rank=0, node_rank=0\n"
-          ]
-        },
-        {
-          "name": "stdout",
-          "output_type": "stream",
-          "text": [
-            "\u001b[36m(RayTrainWorker pid=1179295)\u001b[0m \u2713 Applied AnnDataFileManager patch\n",
-            "\u001b[36m(RayTrainWorker pid=1179295)\u001b[0m \u2713 Applied AnnDataFileManager patch\n",
-            "\u001b[36m(RayTrainWorker pid=1179295)\u001b[0m =========Starting the training on 0 with num threads: 2=========\n"
-          ]
-        },
-        {
-          "name": "stderr",
-          "output_type": "stream",
-          "text": [
-            "\u001b[36m(RayTrainWorker pid=1179295)\u001b[0m \ud83d\udca1 Tip: For seamless cloud uploads and versioning, try installing [litmodels](https://pypi.org/project/litmodels/) to enable LitModelCheckpoint, which syncs automatically with the Lightning model registry.\n",
-            "\u001b[36m(RayTrainWorker pid=1179295)\u001b[0m GPU available: True (cuda), used: True\n",
-            "\u001b[36m(RayTrainWorker pid=1179295)\u001b[0m TPU available: False, using: 0 TPU cores\n",
-            "\u001b[36m(RayTrainWorker pid=1179295)\u001b[0m HPU available: False, using: 0 HPUs\n",
-            "\u001b[36m(RayTrainWorker pid=1179295)\u001b[0m /mnt/hdd1/dung/protoplast-ml-example/.venv/lib/python3.11/site-packages/lightning/fabric/plugins/environments/slurm.py:204: The `srun` command is available on your system but is not used. HINT: If your intention is to run Lightning on SLURM, prepend your python command with `srun` like so: srun python /mnt/hdd1/dung/protoplast-ml-example/.venv/lib/pytho ...\n",
-            "\u001b[36m(RayTrainWorker pid=1179295)\u001b[0m You are using a CUDA device ('NVIDIA GeForce RTX 3080') that has Tensor Cores. To properly utilize them, you should set `torch.set_float32_matmul_precision('medium' | 'high')` which will trade-off precision for performance. For more details, read https://pytorch.org/docs/stable/generated/torch.set_float32_matmul_precision.html#torch.set_float32_matmul_precision\n",
-            "\u001b[36m(RayTrainWorker pid=1179295)\u001b[0m LOCAL_RANK: 0 - CUDA_VISIBLE_DEVICES: [0]\n",
-            "\u001b[36m(RayTrainWorker pid=1179295)\u001b[0m \n",
-            "\u001b[36m(RayTrainWorker pid=1179295)\u001b[0m   | Name    | Type    | Params | Mode  | In sizes     | Out sizes\n",
-            "\u001b[36m(RayTrainWorker pid=1179295)\u001b[0m -----------------------------------------------------------------------\n",
-            "\u001b[36m(RayTrainWorker pid=1179295)\u001b[0m 0 | encoder | Encoder | 8.0 M  | train | [256, 62710] | [256, 16]\n",
-            "\u001b[36m(RayTrainWorker pid=1179295)\u001b[0m 1 | decoder | Decoder | 8.1 M  | train | ?            | ?        \n",
-            "\u001b[36m(RayTrainWorker pid=1179295)\u001b[0m -----------------------------------------------------------------------\n",
-            "\u001b[36m(RayTrainWorker pid=1179295)\u001b[0m 16.2 M    Trainable params\n",
-            "\u001b[36m(RayTrainWorker pid=1179295)\u001b[0m 0         Non-trainable params\n",
-            "\u001b[36m(RayTrainWorker pid=1179295)\u001b[0m 16.2 M    Total params\n",
-            "\u001b[36m(RayTrainWorker pid=1179295)\u001b[0m 64.618    Total estimated model params size (MB)\n",
-            "\u001b[36m(RayTrainWorker pid=1179295)\u001b[0m 27        Modules in train mode\n",
-            "\u001b[36m(RayTrainWorker pid=1179295)\u001b[0m 0         Modules in eval mode\n",
-            "\u001b[36m(RayTrainWorker pid=1179295)\u001b[0m /mnt/hdd1/dung/protoplast-ml-example/.venv/lib/python3.11/site-packages/torch/distributed/distributed_c10d.py:4807: UserWarning: No device id is provided via `init_process_group` or `barrier `. Using the current device set by the user. \n",
-            "\u001b[36m(RayTrainWorker pid=1179295)\u001b[0m   warnings.warn(  # warn only once\n",
-            "\u001b[36m(RayTrainWorker pid=1179295)\u001b[0m /mnt/hdd1/dung/protoplast-ml-example/.venv/lib/python3.11/site-packages/lightning/pytorch/utilities/data.py:123: Your `IterableDataset` has `__len__` defined. In combination with multi-process data loading (when num_workers > 1), `__len__` could be inaccurate if each worker is not configured independently to avoid having duplicate data.\n"
-          ]
-        },
-        {
-          "name": "stdout",
-          "output_type": "stream",
-          "text": [
-            "Sanity Checking: |          | 0/? [00:00<?, ?it/s]\n"
-          ]
-        },
-        {
-          "name": "stderr",
-          "output_type": "stream",
-          "text": [
-            "\u001b[36m(RayTrainWorker pid=1179295)\u001b[0m /mnt/hdd1/dung/protoplast-ml-example/submodules/protoplast/src/protoplast/scrna/anndata/torch_dataloader.py:107: UserWarning: Sparse CSR tensor support is in beta state. If you miss a functionality in the sparse tensor support, please submit a feature request to https://github.com/pytorch/pytorch/issues. (Triggered internally at /pytorch/aten/src/ATen/SparseCsrTensorImpl.cpp:53.)\n",
-            "\u001b[36m(RayTrainWorker pid=1179295)\u001b[0m   return torch.sparse_csr_tensor(\n",
-            "\u001b[36m(RayTrainWorker pid=1179295)\u001b[0m /mnt/hdd1/dung/protoplast-ml-example/.venv/lib/python3.11/site-packages/torch/multiprocessing/reductions.py:473: UserWarning: Sparse CSR tensor support is in beta state. If you miss a functionality in the sparse tensor support, please submit a feature request to https://github.com/pytorch/pytorch/issues. (Triggered internally at /pytorch/aten/src/ATen/SparseCsrTensorImpl.cpp:53.)\n",
-            "\u001b[36m(RayTrainWorker pid=1179295)\u001b[0m   return torch.sparse_compressed_tensor(\n",
-            "\u001b[36m(RayTrainWorker pid=1179295)\u001b[0m /mnt/hdd1/dung/protoplast-ml-example/submodules/protoplast/src/protoplast/scrna/anndata/torch_dataloader.py:107: UserWarning: Sparse CSR tensor support is in beta state. If you miss a functionality in the sparse tensor support, please submit a feature request to https://github.com/pytorch/pytorch/issues. (Triggered internally at /pytorch/aten/src/ATen/SparseCsrTensorImpl.cpp:53.)\n",
-            "\u001b[36m(RayTrainWorker pid=1179295)\u001b[0m   return torch.sparse_csr_tensor(\n"
-          ]
-        },
-        {
-          "name": "stdout",
-          "output_type": "stream",
-          "text": [
-            "Sanity Checking DataLoader 0:   0%|          | 0/2 [00:00<?, ?it/s]\n",
-            "                                                                           \n"
-          ]
-        },
-        {
-          "name": "stderr",
-          "output_type": "stream",
-          "text": [
-            "\u001b[36m(RayTrainWorker pid=1179295)\u001b[0m /mnt/hdd1/dung/protoplast-ml-example/.venv/lib/python3.11/site-packages/lightning/pytorch/trainer/connectors/logger_connector/result.py:434: It is recommended to use `self.log('val_loss', ..., sync_dist=True)` when logging on epoch level in distributed setting to accumulate the metric across devices.\n"
-          ]
-        },
-        {
-          "name": "stdout",
-          "output_type": "stream",
-          "text": [
-            "Epoch 0:   0%|          | 0/4192 [00:00<?, ?it/s] \n",
-            "Epoch 0:   0%|          | 3/4192 [00:21<8:23:39,  0.14it/s, v_num=0] \n",
-            "Epoch 0:   0%|          | 6/4192 [00:21<4:12:52,  0.28it/s, v_num=0]\n",
-            "Epoch 0:   0%|          | 9/4192 [00:21<2:49:14,  0.41it/s, v_num=0]\n",
-            ".\n",
-            ".\n",
-            ".\n",
-            "Epoch 0: 100%|\u2588\u2588\u2588\u2588\u2588\u2588\u2588\u2588\u2588\u2589| 4185/4192 [07:41<00:00,  9.08it/s, v_num=0]\n",
-            "Epoch 0: 100%|\u2588\u2588\u2588\u2588\u2588\u2588\u2588\u2588\u2588\u2589| 4188/4192 [07:41<00:00,  9.08it/s, v_num=0]\n",
-            "Epoch 0: 100%|\u2588\u2588\u2588\u2588\u2588\u2588\u2588\u2588\u2588\u2589| 4189/4192 [07:41<00:00,  9.08it/s, v_num=0]\n",
-            "Epoch 0: 100%|\u2588\u2588\u2588\u2588\u2588\u2588\u2588\u2588\u2588\u2588| 4192/4192 [07:41<00:00,  9.09it/s, v_num=0]\n",
-            "\u001b[36m(RayTrainWorker pid=1179295)\u001b[0m \n",
-            "Validation: |          | 0/? [00:00<?, ?it/s]\u001b[A\n",
-            "\u001b[36m(RayTrainWorker pid=1179295)\u001b[0m \n",
-            "Validation:   0%|          | 0/1024 [00:00<?, ?it/s]\u001b[A\n",
-            "Validation DataLoader 0:   0%|          | 0/1024 [00:00<?, ?it/s]\u001b[A\n",
-            "Validation DataLoader 0:   0%|          | 1/1024 [00:00<00:06, 148.72it/s]\u001b[A\n",
-            ".\n",
-            ".\n",
-            ".\n",
-            "Validation DataLoader 0: 100%|\u2588\u2588\u2588\u2588\u2588\u2588\u2588\u2588\u2588\u2589| 1022/1024 [01:34<00:00, 10.83it/s]\u001b[A\n",
-            "Validation DataLoader 0: 100%|\u2588\u2588\u2588\u2588\u2588\u2588\u2588\u2588\u2588\u2589| 1023/1024 [01:34<00:00, 10.84it/s]\u001b[A\n",
-            "Validation DataLoader 0: 100%|\u2588\u2588\u2588\u2588\u2588\u2588\u2588\u2588\u2588\u2588| 1024/1024 [01:34<00:00, 10.85it/s]\u001b[A\n",
-            "Epoch 0: 100%|\u2588\u2588\u2588\u2588\u2588\u2588\u2588\u2588\u2588\u2588| 4192/4192 [09:40<00:00,  7.22it/s, v_num=0]       \u001b[A\n"
-          ]
-        },
-        {
-          "name": "stderr",
-          "output_type": "stream",
-          "text": [
-            "\u001b[36m(RayTrainWorker pid=1179295)\u001b[0m Checkpoint successfully created at: Checkpoint(filesystem=local, path=/home/dtran/protoplast_results/TorchTrainer_2025-09-24_11-10-35/TorchTrainer_17e07_00000_0_2025-09-24_11-10-35/checkpoint_000000)\n"
-          ]
-        },
-        {
-          "name": "stdout",
-          "output_type": "stream",
-          "text": [
-            "Epoch 0: 100%|\u2588\u2588\u2588\u2588\u2588\u2588\u2588\u2588\u2588\u2588| 4192/4192 [09:41<00:00,  7.21it/s, v_num=0]\n"
-          ]
-        },
-        {
-          "name": "stderr",
-          "output_type": "stream",
-          "text": [
-            "\u001b[36m(RayTrainWorker pid=1179295)\u001b[0m `Trainer.fit` stopped: `max_epochs=1` reached.\n"
-          ]
-        },
-        {
-          "name": "stdout",
-          "output_type": "stream",
-          "text": [
-            "Epoch 0: 100%|\u2588\u2588\u2588\u2588\u2588\u2588\u2588\u2588\u2588\u2588| 4192/4192 [09:41<00:00,  7.20it/s, v_num=0]\n"
-          ]
-        }
-      ],
-      "source": [
-        "%%time\n",
-        "autoencoder_trainer = RayTrainRunner(\n",
-        "    CiteAutoencoder,\n",
-        "    Dcl,\n",
-        "    [\"nfeatures_rna\", \"nfeatures_pro\", \"hidden_rna\", \"hidden_pro\", \"latent_dim\", \"p\", \"lr\"],\n",
-        "    metadata_cb=ae_metadata_cb,\n",
-        ")"
-      ]
-    },
-    {
-      "cell_type": "markdown",
-      "id": "dd758cb8",
-      "metadata": {},
-      "source": [
-        "On a machine with **1 GPU (NVIDIA GeForce RTX 3080 - 12GiB) + 96 CPUs + 125GiB RAM**, `autoencoder_trainer()` finished in **11 minutes**"
-      ]
-    },
-    {
-      "cell_type": "code",
-      "execution_count": 15,
-      "id": "ulZA",
-      "metadata": {
-        "scrolled": true
-      },
-      "outputs": [
-        {
-          "name": "stdout",
-          "output_type": "stream",
-          "text": [
-            "Using 1 workers with {'CPU': 2} each\n",
-            "=========Length of val_split 65 length of test_split 0 length of train_split 262\n",
-            "=========Length of after dropping remainder val_split 64 length of test_split 0 length of train_split 262\n"
-          ]
-        },
-        {
-          "name": "stderr",
-          "output_type": "stream",
-          "text": [
-            "2025-09-24 11:10:35,128\tINFO tune.py:616 -- [output] This uses the legacy output and progress reporter, as Jupyter notebooks are not supported by the new engine, yet. For more information, please see https://github.com/ray-project/ray/issues/36949\n"
-          ]
-        },
-        {
-          "name": "stdout",
-          "output_type": "stream",
-          "text": [
-            "Data splitting time: 27.18 seconds\n",
-            "Spawning Ray worker and initiating distributed training\n",
-            "== Status ==\n",
-            "Current time: 2025-09-24 11:10:35 (running for 00:00:00.13)\n",
-            "Using FIFO scheduling algorithm.\n",
-            "Logical resource usage: 0/96 CPUs, 0/1 GPUs (0.0/1.0 accelerator_type:G)\n",
-            "Result logdir: /tmp/ray/session_2025-09-24_11-10-04_295190_1141478/artifacts/2025-09-24_11-10-35/TorchTrainer_2025-09-24_11-10-35/driver_artifacts\n",
-            "Number of trials: 1/1 (1 PENDING)\n",
-            "\n",
-            "\n",
-            "== Status ==\n",
-            "Current time: 2025-09-24 11:10:45 (running for 00:00:10.26)\n",
-            "Using FIFO scheduling algorithm.\n",
-            "Logical resource usage: 3.0/96 CPUs, 1.0/1 GPUs (0.0/1.0 accelerator_type:G)\n",
-            "Result logdir: /tmp/ray/session_2025-09-24_11-10-04_295190_1141478/artifacts/2025-09-24_11-10-35/TorchTrainer_2025-09-24_11-10-35/driver_artifacts\n",
-            "Number of trials: 1/1 (1 RUNNING)\n",
-            "\n",
-            "\n",
-            "== Status ==\n",
-            "Current time: 2025-09-24 11:20:54 (running for 00:10:19.02)\n",
-            "Using FIFO scheduling algorithm.\n",
-            "Logical resource usage: 3.0/96 CPUs, 1.0/1 GPUs (0.0/1.0 accelerator_type:G)\n",
-            "Result logdir: /tmp/ray/session_2025-09-24_11-10-04_295190_1141478/artifacts/2025-09-24_11-10-35/TorchTrainer_2025-09-24_11-10-35/driver_artifacts\n",
-            "Number of trials: 1/1 (1 RUNNING)\n",
-            "\n",
-            "\n"
-          ]
-        },
-        {
-          "name": "stderr",
-          "output_type": "stream",
-          "text": [
-            "2025-09-24 11:20:56,141\tINFO tune.py:1009 -- Wrote the latest version of all result files and experiment state to '/home/dtran/protoplast_results/TorchTrainer_2025-09-24_11-10-35' in 0.0226s.\n",
-            "2025-09-24 11:20:56,145\tINFO tune.py:1041 -- Total run time: 621.02 seconds (620.98 seconds for the tuning loop).\n"
-          ]
-        },
-        {
-          "name": "stdout",
-          "output_type": "stream",
-          "text": [
-            "== Status ==\n",
-            "Current time: 2025-09-24 11:20:56 (running for 00:10:21.00)\n",
-            "Using FIFO scheduling algorithm.\n",
-            "Logical resource usage: 3.0/96 CPUs, 1.0/1 GPUs (0.0/1.0 accelerator_type:G)\n",
-            "Result logdir: /tmp/ray/session_2025-09-24_11-10-04_295190_1141478/artifacts/2025-09-24_11-10-35/TorchTrainer_2025-09-24_11-10-35/driver_artifacts\n",
-            "Number of trials: 1/1 (1 TERMINATED)\n",
-            "\n",
-            "\n",
-            "CPU times: user 33.6 s, sys: 4.37 s, total: 38 s\n",
-            "Wall time: 10min 50s\n"
-          ]
-        }
-      ],
-      "source": [
-        "%%time\n",
-        "autoencoder_trainer.train(\n",
-        "    file_paths,\n",
-        "    batch_size,  # 2000\n",
-        "    test_size,  # 0.0\n",
-        "    val_size,  # 0.2\n",
-        "    thread_per_worker=thread_per_worker,\n",
-        ")\n",
-        "ray.shutdown()"
-      ]
-    },
-    {
-      "cell_type": "markdown",
-      "id": "b3b3ce28-2f5f-43f1-ba00-465612f9925f",
-      "metadata": {},
-      "source": [
-        "## 5. DistributedClassifierTrainingPlan\n",
-        "- **ClassifierTrainingPlan** (from `scvi-tools`) is not a model itself, but a training plan.  \n",
-        "  Its purpose is to coordinate the entire training workflow of an scvi-tools classifier, including optimization, scheduling, and evaluation.  \n",
-        "- For details, see the [source code](https://github.com/scverse/scvi-tools/blob/main/src/scvi/train/_trainingplans.py#L1479)."
-      ]
-    },
-    {
-      "cell_type": "code",
-      "execution_count": 16,
-      "id": "Pvdt",
-      "metadata": {},
-      "outputs": [],
-      "source": [
-        "# install scvi:\n",
-        "# uv add scvi-tools in terminal"
-      ]
-    },
-    {
-      "cell_type": "markdown",
-      "id": "3314d4b8-d322-4b92-97b8-8daa97889182",
-      "metadata": {},
-      "source": [
-        "### Classifier Training metadata callback\n",
-        "Calls `cell_line_metadata_cb` to extract `num_genes` and `num_classes` from the input AnnData object."
-      ]
-    },
-    {
-      "cell_type": "code",
-      "execution_count": 17,
-      "id": "9555c00c-483e-46fd-8188-4318392a8eaf",
-      "metadata": {},
-      "outputs": [
-        {
-          "name": "stdout",
-          "output_type": "stream",
-          "text": [
-            "CPU times: user 22 \u03bcs, sys: 0 ns, total: 22 \u03bcs\n",
-            "Wall time: 33.6 \u03bcs\n"
-          ]
-        }
-      ],
-      "source": [
-        "%%time\n",
-        "\n",
-        "\n",
-        "def clf_metadata_cb(ad, metadata):\n",
-        "    # Populate num_genes / num_classes from the AnnData file\n",
-        "    cell_line_metadata_cb(ad, metadata)\n",
-        "\n",
-        "    # Create the classifier instance and attach it to metadata\n",
-        "    metadata[\"classifier\"] = Classifier(\n",
-        "        n_input=metadata[\"num_genes\"],\n",
-        "        n_labels=metadata[\"num_classes\"],\n",
-        "        logits=True,  # ClassifierTrainingPlan requirement that the module returns logits\n",
-        "    )\n",
-        "    metadata[\"lr\"] = 1e-3\n",
-        "    metadata[\"weight_decay\"] = 1e-6\n",
-        "    metadata[\"eps\"] = 0.01\n",
-        "    metadata[\"optimizer\"] = \"Adam\""
-      ]
-    },
-    {
-      "cell_type": "markdown",
-      "id": "c2242850-ae97-4df4-9f84-761faee01690",
-      "metadata": {},
-      "source": [
-        "The `DistributedClassifierTrainingPlan` subclass extends `ClassifierTrainingPlan` by explicitly defining its own `training_step` and `validation_step`:"
-      ]
-    },
-    {
-      "cell_type": "code",
-      "execution_count": 18,
-      "id": "d597c453-0ec2-409a-b7dd-198b891fdd33",
-      "metadata": {},
-      "outputs": [
-        {
-          "name": "stdout",
-          "output_type": "stream",
-          "text": [
-            "CPU times: user 292 \u03bcs, sys: 0 ns, total: 292 \u03bcs\n",
-            "Wall time: 303 \u03bcs\n"
-          ]
-        }
-      ],
-      "source": [
-        "%%time\n",
-        "\n",
-        "\n",
-        "class DistributedClassifierTrainingPlan(ClassifierTrainingPlan):\n",
-        "    def training_step(self, batch, batch_idx):\n",
-        "        \"\"\"Training step for classifier training.\"\"\"\n",
-        "        x, y = batch\n",
-        "        soft_prediction = self.forward(x)\n",
-        "        loss = self.loss_fn(soft_prediction, y.view(-1).long())\n",
-        "        self.log(\"train_loss\", loss, on_epoch=True, prog_bar=True)\n",
-        "        return loss\n",
-        "\n",
-        "    def validation_step(self, batch, batch_idx):\n",
-        "        \"\"\"Validation step for classifier training.\"\"\"\n",
-        "        x, y = batch\n",
-        "        soft_prediction = self.forward(x)\n",
-        "        loss = self.loss_fn(soft_prediction, y.view(-1).long())\n",
-        "        self.log(\"validation_loss\", loss)"
-      ]
-    },
-    {
-      "cell_type": "markdown",
-      "id": "c4fc5d5b-1707-493d-a388-a1a3380c1853",
-      "metadata": {},
-      "source": [
-        "### Executing ClassifierTrainingPlan"
-      ]
-    },
-    {
-      "cell_type": "code",
-      "execution_count": 19,
-      "id": "507c8f51-7e90-45b5-b455-0ba5ddbf033f",
-      "metadata": {
-        "scrolled": true
-      },
-      "outputs": [
-        {
-          "name": "stderr",
-          "output_type": "stream",
-          "text": [
-            "2025-09-24 11:21:28,271\tINFO worker.py:1951 -- Started a local Ray instance.\n"
-          ]
-        },
-        {
-          "name": "stdout",
-          "output_type": "stream",
-          "text": [
-            "CPU times: user 110 ms, sys: 253 ms, total: 362 ms\n",
-            "Wall time: 3.72 s\n",
-            "\u001b[36m(TrainTrainable pid=1192577)\u001b[0m \u2713 Applied AnnDataFileManager patch\n",
-            "\u001b[36m(TrainTrainable pid=1192577)\u001b[0m \u2713 Applied AnnDataFileManager patch\n"
-          ]
-        },
-        {
-          "name": "stderr",
-          "output_type": "stream",
-          "text": [
-            "\u001b[36m(RayTrainWorker pid=1192897)\u001b[0m Setting up process group for: env:// [rank=0, world_size=1]\n",
-            "\u001b[36m(TorchTrainer pid=1192577)\u001b[0m Started distributed worker processes: \n",
-            "\u001b[36m(TorchTrainer pid=1192577)\u001b[0m - (node_id=f36cc440d80dfc099158a8e73d3e08d928895b6225c2d92911afd93b, ip=192.168.1.226, pid=1192897) world_rank=0, local_rank=0, node_rank=0\n"
-          ]
-        },
-        {
-          "name": "stdout",
-          "output_type": "stream",
-          "text": [
-            "\u001b[36m(RayTrainWorker pid=1192897)\u001b[0m \u2713 Applied AnnDataFileManager patch\n",
-            "\u001b[36m(RayTrainWorker pid=1192897)\u001b[0m \u2713 Applied AnnDataFileManager patch\n"
-          ]
-        },
-        {
-          "name": "stderr",
-          "output_type": "stream",
-          "text": [
-            "\u001b[36m(RayTrainWorker pid=1192897)\u001b[0m \ud83d\udca1 Tip: For seamless cloud uploads and versioning, try installing [litmodels](https://pypi.org/project/litmodels/) to enable LitModelCheckpoint, which syncs automatically with the Lightning model registry.\n",
-            "\u001b[36m(RayTrainWorker pid=1192897)\u001b[0m GPU available: True (cuda), used: True\n",
-            "\u001b[36m(RayTrainWorker pid=1192897)\u001b[0m TPU available: False, using: 0 TPU cores\n",
-            "\u001b[36m(RayTrainWorker pid=1192897)\u001b[0m HPU available: False, using: 0 HPUs\n",
-            "\u001b[36m(RayTrainWorker pid=1192897)\u001b[0m /mnt/hdd1/dung/protoplast-ml-example/.venv/lib/python3.11/site-packages/lightning/fabric/plugins/environments/slurm.py:204: The `srun` command is available on your system but is not used. HINT: If your intention is to run Lightning on SLURM, prepend your python command with `srun` like so: srun python /mnt/hdd1/dung/protoplast-ml-example/.venv/lib/pytho ...\n",
-            "\u001b[36m(RayTrainWorker pid=1192897)\u001b[0m You are using a CUDA device ('NVIDIA GeForce RTX 3080') that has Tensor Cores. To properly utilize them, you should set `torch.set_float32_matmul_precision('medium' | 'high')` which will trade-off precision for performance. For more details, read https://pytorch.org/docs/stable/generated/torch.set_float32_matmul_precision.html#torch.set_float32_matmul_precision\n"
-          ]
-        },
-        {
-          "name": "stdout",
-          "output_type": "stream",
-          "text": [
-            "\u001b[36m(RayTrainWorker pid=1192897)\u001b[0m =========Starting the training on 0 with num threads: 2=========\n"
-          ]
-        },
-        {
-          "name": "stderr",
-          "output_type": "stream",
-          "text": [
-            "\u001b[36m(RayTrainWorker pid=1192897)\u001b[0m LOCAL_RANK: 0 - CUDA_VISIBLE_DEVICES: [0]\n",
-            "\u001b[36m(RayTrainWorker pid=1192897)\u001b[0m \n",
-            "\u001b[36m(RayTrainWorker pid=1192897)\u001b[0m   | Name    | Type             | Params | Mode \n",
-            "\u001b[36m(RayTrainWorker pid=1192897)\u001b[0m -----------------------------------------------------\n",
-            "\u001b[36m(RayTrainWorker pid=1192897)\u001b[0m 0 | module  | Classifier       | 8.0 M  | train\n",
-            "\u001b[36m(RayTrainWorker pid=1192897)\u001b[0m 1 | loss_fn | CrossEntropyLoss | 0      | train\n",
-            "\u001b[36m(RayTrainWorker pid=1192897)\u001b[0m -----------------------------------------------------\n",
-            "\u001b[36m(RayTrainWorker pid=1192897)\u001b[0m 8.0 M     Trainable params\n",
-            "\u001b[36m(RayTrainWorker pid=1192897)\u001b[0m 0         Non-trainable params\n",
-            "\u001b[36m(RayTrainWorker pid=1192897)\u001b[0m 8.0 M     Total params\n",
-            "\u001b[36m(RayTrainWorker pid=1192897)\u001b[0m 32.135    Total estimated model params size (MB)\n",
-            "\u001b[36m(RayTrainWorker pid=1192897)\u001b[0m 11        Modules in train mode\n",
-            "\u001b[36m(RayTrainWorker pid=1192897)\u001b[0m 0         Modules in eval mode\n",
-            "\u001b[36m(RayTrainWorker pid=1192897)\u001b[0m /mnt/hdd1/dung/protoplast-ml-example/.venv/lib/python3.11/site-packages/torch/distributed/distributed_c10d.py:4807: UserWarning: No device id is provided via `init_process_group` or `barrier `. Using the current device set by the user. \n",
-            "\u001b[36m(RayTrainWorker pid=1192897)\u001b[0m   warnings.warn(  # warn only once\n",
-            "\u001b[36m(RayTrainWorker pid=1192897)\u001b[0m /mnt/hdd1/dung/protoplast-ml-example/.venv/lib/python3.11/site-packages/lightning/pytorch/utilities/data.py:123: Your `IterableDataset` has `__len__` defined. In combination with multi-process data loading (when num_workers > 1), `__len__` could be inaccurate if each worker is not configured independently to avoid having duplicate data.\n"
-          ]
-        },
-        {
-          "name": "stdout",
-          "output_type": "stream",
-          "text": [
-            "Sanity Checking: |          | 0/? [00:00<?, ?it/s]\n"
-          ]
-        },
-        {
-          "name": "stderr",
-          "output_type": "stream",
-          "text": [
-            "\u001b[36m(RayTrainWorker pid=1192897)\u001b[0m /mnt/hdd1/dung/protoplast-ml-example/submodules/protoplast/src/protoplast/scrna/anndata/torch_dataloader.py:107: UserWarning: Sparse CSR tensor support is in beta state. If you miss a functionality in the sparse tensor support, please submit a feature request to https://github.com/pytorch/pytorch/issues. (Triggered internally at /pytorch/aten/src/ATen/SparseCsrTensorImpl.cpp:53.)\n",
-            "\u001b[36m(RayTrainWorker pid=1192897)\u001b[0m   return torch.sparse_csr_tensor(\n",
-            "\u001b[36m(RayTrainWorker pid=1192897)\u001b[0m /mnt/hdd1/dung/protoplast-ml-example/.venv/lib/python3.11/site-packages/torch/multiprocessing/reductions.py:473: UserWarning: Sparse CSR tensor support is in beta state. If you miss a functionality in the sparse tensor support, please submit a feature request to https://github.com/pytorch/pytorch/issues. (Triggered internally at /pytorch/aten/src/ATen/SparseCsrTensorImpl.cpp:53.)\n",
-            "\u001b[36m(RayTrainWorker pid=1192897)\u001b[0m   return torch.sparse_compressed_tensor(\n"
-          ]
-        },
-        {
-          "name": "stdout",
-          "output_type": "stream",
-          "text": [
-            "Sanity Checking DataLoader 0:   0%|          | 0/2 [00:00<?, ?it/s]\n",
-            "Sanity Checking DataLoader 0:  50%|\u2588\u2588\u2588\u2588\u2588     | 1/2 [00:00<00:00,  5.45it/s]\n"
-          ]
-        },
-        {
-          "name": "stderr",
-          "output_type": "stream",
-          "text": [
-            "\u001b[36m(RayTrainWorker pid=1192897)\u001b[0m /mnt/hdd1/dung/protoplast-ml-example/submodules/protoplast/src/protoplast/scrna/anndata/torch_dataloader.py:107: UserWarning: Sparse CSR tensor support is in beta state. If you miss a functionality in the sparse tensor support, please submit a feature request to https://github.com/pytorch/pytorch/issues. (Triggered internally at /pytorch/aten/src/ATen/SparseCsrTensorImpl.cpp:53.)\n",
-            "\u001b[36m(RayTrainWorker pid=1192897)\u001b[0m   return torch.sparse_csr_tensor(\n",
-            "\u001b[36m(RayTrainWorker pid=1192897)\u001b[0m /mnt/hdd1/dung/protoplast-ml-example/.venv/lib/python3.11/site-packages/lightning/pytorch/trainer/connectors/logger_connector/result.py:434: It is recommended to use `self.log('validation_loss', ..., sync_dist=True)` when logging on epoch level in distributed setting to accumulate the metric across devices.\n"
-          ]
-        },
-        {
-          "name": "stdout",
-          "output_type": "stream",
-          "text": [
-            "Epoch 0:   0%|          | 0/4192 [00:00<?, ?it/s]                          \n",
-            "Epoch 0:   0%|          | 1/4192 [00:21<25:27:26,  0.05it/s, v_num=0, train_loss_step=3.980]\n",
-            "Epoch 0:   0%|          | 4/4192 [00:22<6:24:31,  0.18it/s, v_num=0, train_loss_step=3.170] \n",
-            ".\n",
-            ".\n",
-            ".\n",
-            "Epoch 0: 100%|\u2588\u2588\u2588\u2588\u2588\u2588\u2588\u2588\u2588\u2589| 4187/4192 [06:53<00:00, 10.13it/s, v_num=0, train_loss_step=0.0821]\n",
-            "Epoch 0: 100%|\u2588\u2588\u2588\u2588\u2588\u2588\u2588\u2588\u2588\u2589| 4191/4192 [06:53<00:00, 10.14it/s, v_num=0, train_loss_step=0.0651]\n",
-            "Epoch 0: 100%|\u2588\u2588\u2588\u2588\u2588\u2588\u2588\u2588\u2588\u2588| 4192/4192 [06:53<00:00, 10.14it/s, v_num=0, train_loss_step=0.104] \n",
-            "Validation: |          | 0/? [00:00<?, ?it/s]\u001b[A\n",
-            "\u001b[36m(RayTrainWorker pid=1192897)\u001b[0m \n",
-            "Validation:   0%|          | 0/1024 [00:00<?, ?it/s]\u001b[A\n",
-            "Validation DataLoader 0:   0%|          | 0/1024 [00:00<?, ?it/s]\u001b[A\n",
-            ".\n",
-            ".\n",
-            ".\n",
-            "Validation DataLoader 0: 100%|\u2588\u2588\u2588\u2588\u2588\u2588\u2588\u2588\u2588\u2589| 1021/1024 [01:29<00:00, 11.40it/s]\u001b[A\n",
-            "Validation DataLoader 0: 100%|\u2588\u2588\u2588\u2588\u2588\u2588\u2588\u2588\u2588\u2589| 1022/1024 [01:29<00:00, 11.41it/s]\u001b[A\n",
-            "Validation DataLoader 0: 100%|\u2588\u2588\u2588\u2588\u2588\u2588\u2588\u2588\u2588\u2589| 1023/1024 [01:29<00:00, 11.42it/s]\u001b[A\n",
-            "Validation DataLoader 0: 100%|\u2588\u2588\u2588\u2588\u2588\u2588\u2588\u2588\u2588\u2588| 1024/1024 [01:29<00:00, 11.43it/s]\u001b[A\n",
-            "Epoch 0: 100%|\u2588\u2588\u2588\u2588\u2588\u2588\u2588\u2588\u2588\u2588| 4192/4192 [08:45<00:00,  7.98it/s, v_num=0, train_loss_step=0.104]\n"
-          ]
-        },
-        {
-          "name": "stderr",
-          "output_type": "stream",
-          "text": [
-            "\u001b[36m(RayTrainWorker pid=1192897)\u001b[0m /mnt/hdd1/dung/protoplast-ml-example/.venv/lib/python3.11/site-packages/lightning/pytorch/trainer/connectors/logger_connector/result.py:434: It is recommended to use `self.log('train_loss', ..., sync_dist=True)` when logging on epoch level in distributed setting to accumulate the metric across devices.\n",
-            "\u001b[36m(RayTrainWorker pid=1192897)\u001b[0m Checkpoint successfully created at: Checkpoint(filesystem=local, path=/home/dtran/protoplast_results/TorchTrainer_2025-09-24_11-21-49/TorchTrainer_a9e9d_00000_0_2025-09-24_11-21-49/checkpoint_000000)\n"
-          ]
-        },
-        {
-          "name": "stdout",
-          "output_type": "stream",
-          "text": [
-            "Epoch 0: 100%|\u2588\u2588\u2588\u2588\u2588\u2588\u2588\u2588\u2588\u2588| 4192/4192 [08:46<00:00,  7.97it/s, v_num=0, train_loss_step=0.104, train_loss_epoch=0.181]\n"
-          ]
-        },
-        {
-          "name": "stderr",
-          "output_type": "stream",
-          "text": [
-            "\u001b[36m(RayTrainWorker pid=1192897)\u001b[0m `Trainer.fit` stopped: `max_epochs=1` reached.\n"
-          ]
-        },
-        {
-          "name": "stdout",
-          "output_type": "stream",
-          "text": [
-            "Epoch 0: 100%|\u2588\u2588\u2588\u2588\u2588\u2588\u2588\u2588\u2588\u2588| 4192/4192 [08:46<00:00,  7.96it/s, v_num=0, train_loss_step=0.104, train_loss_epoch=0.181]\n"
-          ]
-        },
-        {
-          "name": "stderr",
-          "output_type": "stream",
-          "text": [
-            "\u001b[36m(RayTrainWorker pid=1192897)\u001b[0m [rank0]:[W924 11:31:16.949850381 ProcessGroupNCCL.cpp:1538] Warning: WARNING: destroy_process_group() was not called before program exit, which can leak resources. For more info, please see https://pytorch.org/docs/stable/distributed.html#shutdown (function operator())\n"
-          ]
-        }
-      ],
-      "source": [
-        "%%time\n",
-        "from protoplast.scrna.anndata.torch_dataloader import DistributedCellLineAnnDataset as Dcl\n",
-        "\n",
-        "ClassifierTrainingPlan_trainer = RayTrainRunner(\n",
-        "    Model=DistributedClassifierTrainingPlan,\n",
-        "    Ds=Dcl,\n",
-        "    model_keys=[\"classifier\", \"lr\", \"weight_decay\", \"eps\", \"optimizer\"],\n",
-        "    metadata_cb=clf_metadata_cb,\n",
-        ")"
-      ]
-    },
-    {
-      "cell_type": "markdown",
-      "id": "c6dbfa49-e971-4ccf-ac3a-0cfdf9064274",
-      "metadata": {},
-      "source": [
-        "On a machine with **1 GPU (NVIDIA GeForce RTX 3080 - 12GiB) + 96 CPUs + 125GiB RAM**, `ClassifierTrainingPlan_trainer()` finished in **10 minutes**"
-      ]
-    },
-    {
-      "cell_type": "code",
-      "execution_count": 20,
-      "id": "ffde478a-93ef-43b8-a7d9-03c9efd36ac1",
-      "metadata": {
-        "scrolled": true
-      },
-      "outputs": [
-        {
-          "name": "stdout",
-          "output_type": "stream",
-          "text": [
-            "Using 1 workers with {'CPU': 2} each\n",
-            "=========Length of val_split 65 length of test_split 0 length of train_split 262\n",
-            "=========Length of after dropping remainder val_split 64 length of test_split 0 length of train_split 262\n"
-          ]
-        },
-        {
-          "name": "stderr",
-          "output_type": "stream",
-          "text": [
-            "2025-09-24 11:21:49,629\tINFO tune.py:616 -- [output] This uses the legacy output and progress reporter, as Jupyter notebooks are not supported by the new engine, yet. For more information, please see https://github.com/ray-project/ray/issues/36949\n"
-          ]
-        },
-        {
-          "name": "stdout",
-          "output_type": "stream",
-          "text": [
-            "Data splitting time: 20.11 seconds\n",
-            "Spawning Ray worker and initiating distributed training\n",
-            "== Status ==\n",
-            "Current time: 2025-09-24 11:21:50 (running for 00:00:00.78)\n",
-            "Using FIFO scheduling algorithm.\n",
-            "Logical resource usage: 0/96 CPUs, 0/1 GPUs (0.0/1.0 accelerator_type:G)\n",
-            "Result logdir: /tmp/ray/session_2025-09-24_11-21-25_731212_1141478/artifacts/2025-09-24_11-21-49/TorchTrainer_2025-09-24_11-21-49/driver_artifacts\n",
-            "Number of trials: 1/1 (1 PENDING)\n",
-            "\n",
-            "\n",
-            "== Status ==\n",
-            "Current time: 2025-09-24 11:22:00 (running for 00:00:10.91)\n",
-            "Using FIFO scheduling algorithm.\n",
-            "Logical resource usage: 3.0/96 CPUs, 1.0/1 GPUs (0.0/1.0 accelerator_type:G)\n",
-            "Result logdir: /tmp/ray/session_2025-09-24_11-21-25_731212_1141478/artifacts/2025-09-24_11-21-49/TorchTrainer_2025-09-24_11-21-49/driver_artifacts\n",
-            "Number of trials: 1/1 (1 RUNNING)\n",
-            "\n",
-            "\n",
-            "== Status ==\n",
-            "Current time: 2025-09-24 11:31:12 (running for 00:09:22.64)\n",
-            "Using FIFO scheduling algorithm.\n",
-            "Logical resource usage: 3.0/96 CPUs, 1.0/1 GPUs (0.0/1.0 accelerator_type:G)\n",
-            "Result logdir: /tmp/ray/session_2025-09-24_11-21-25_731212_1141478/artifacts/2025-09-24_11-21-49/TorchTrainer_2025-09-24_11-21-49/driver_artifacts\n",
-            "Number of trials: 1/1 (1 RUNNING)\n",
-            "\n",
-            "\n"
-          ]
-        },
-        {
-          "name": "stderr",
-          "output_type": "stream",
-          "text": [
-            "2025-09-24 11:31:18,075\tINFO tune.py:1009 -- Wrote the latest version of all result files and experiment state to '/home/dtran/protoplast_results/TorchTrainer_2025-09-24_11-21-49' in 2.7891s.\n",
-            "2025-09-24 11:31:18,084\tINFO tune.py:1041 -- Total run time: 568.46 seconds (565.64 seconds for the tuning loop).\n"
-          ]
-        },
-        {
-          "name": "stdout",
-          "output_type": "stream",
-          "text": [
-            "== Status ==\n",
-            "Current time: 2025-09-24 11:31:18 (running for 00:09:28.43)\n",
-            "Using FIFO scheduling algorithm.\n",
-            "Logical resource usage: 3.0/96 CPUs, 1.0/1 GPUs (0.0/1.0 accelerator_type:G)\n",
-            "Result logdir: /tmp/ray/session_2025-09-24_11-21-25_731212_1141478/artifacts/2025-09-24_11-21-49/TorchTrainer_2025-09-24_11-21-49/driver_artifacts\n",
-            "Number of trials: 1/1 (1 TERMINATED)\n",
-            "\n",
-            "\n",
-            "CPU times: user 45.3 s, sys: 17.4 s, total: 1min 2s\n",
-            "Wall time: 9min 50s\n"
-          ]
-        }
-      ],
-      "source": [
-        "%%time\n",
-        "ClassifierTrainingPlan_trainer.train(\n",
-        "    file_paths,\n",
-        "    batch_size,  # 2000\n",
-        "    test_size,  # 0.0\n",
-        "    val_size,  # 0.2\n",
-        "    thread_per_worker=thread_per_worker,  # 2\n",
-        ")\n",
-        "ray.shutdown()"
-      ]
-    },
-    {
-      "cell_type": "code",
-      "execution_count": null,
-      "id": "eb31ae90-ccef-4612-958c-b17500a3529c",
-      "metadata": {},
-      "outputs": [],
-      "source": []
-    }
-  ],
-  "metadata": {
-    "kernelspec": {
-      "display_name": "Python (protoplast-ml-example)",
-      "language": "python",
-      "name": "protoplast-ml-example"
-    },
-    "language_info": {
-      "codemirror_mode": {
-        "name": "ipython",
-        "version": 3
-      },
-      "file_extension": ".py",
-      "mimetype": "text/x-python",
-      "name": "python",
-      "nbconvert_exporter": "python",
-      "pygments_lexer": "ipython3",
-      "version": "3.11.13"
-    }
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "id": "MJUe",
+   "metadata": {},
+   "source": [
+    "# Classification Models for Single-Cell Data with PROTOplast"
+   ]
   },
-  "nbformat": 4,
-  "nbformat_minor": 5
+  {
+   "cell_type": "markdown",
+   "id": "453a8f1a",
+   "metadata": {},
+   "source": [
+    "This tutorial demonstrates how to use PROTOplast to train different classification models in PyTorch with the `h5ad` format."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "2713b010",
+   "metadata": {},
+   "source": [
+    "**Download the Tahoe-100M `h5ad` files**\n",
+    "- The Tahoe-100M dataset can be downloaded in `h5ad` format from the **Arc Institute Google Cloud Storage**.\n",
+    "- For step-by-step instructions, see the [official tutorial](https://github.com/ArcInstitute/arc-virtual-cell-atlas/blob/main/tahoe-100M/README.md)."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "vblA",
+   "metadata": {},
+   "source": [
+    "**Setup**  \n",
+    "- Configure the training environment for single-cell RNA sequencing (scRNA-seq) data using **PROTOplast** in combination with **PyTorch Lightning** and **Ray**."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 1,
+   "id": "bkHC",
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "✓ Applied AnnDataFileManager patch, AnnData cannot be imported after the patch!\n",
+      "✓ Applied AnnDataFileManager patch, AnnData cannot be imported after the patch!\n",
+      "CPU times: user 18.9 s, sys: 1.54 s, total: 20.4 s\n",
+      "Wall time: 8.36 s\n"
+     ]
+    }
+   ],
+   "source": [
+    "%%time\n",
+    "import anndata\n",
+    "import numpy as np\n",
+    "import ray\n",
+    "\n",
+    "# models\n",
+    "from protoplast.scrna.anndata.lightning_models import LinearClassifier\n",
+    "from protoplast.scrna.anndata.torch_dataloader import DistributedCellLineAnnDataset as Dcl\n",
+    "from protoplast.scrna.anndata.torch_dataloader import cell_line_metadata_cb\n",
+    "from protoplast.scrna.anndata.trainer import RayTrainRunner\n",
+    "from ray.train.lightning import RayDDPStrategy\n",
+    "from scsims.model import SIMSClassifier\n",
+    "\n",
+    "# scvi training plan\n",
+    "## install scvi-tools if needed:\n",
+    "## uv add scvi-tools\n",
+    "from scvi.module import Classifier\n",
+    "from scvi.train import ClassifierTrainingPlan"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "6011fb16",
+   "metadata": {},
+   "source": [
+    "## 1. Load the Tahoe 100-M Dataset (`h5ad`)\n",
+    "- `file_paths`: Plate 12 from Tahoe-100M (The largest file: 35 GB) is used as a demo. To add more plates, append their `.h5ad` file paths to the list, separated by commas\n",
+    "- `batch_size`: number of samples per training batch\n",
+    "- `test_size`: fraction of data reserved for testing (use `0.0` if no test set is needed)\n",
+    "- `val_size`: fraction of data reserved for validation \n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 2,
+   "id": "Xref",
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "CPU times: user 10 μs, sys: 1 μs, total: 11 μs\n",
+      "Wall time: 21.9 μs\n"
+     ]
+    }
+   ],
+   "source": [
+    "%%time\n",
+    "file_paths = [\"/mnt/hdd2/tan/tahoe100m/plate12_filt_Vevo_Tahoe100M_WServicesFrom_ParseGigalab.h5ad\"]\n",
+    "batch_size = 2000\n",
+    "test_size = 0.0\n",
+    "val_size = 0.2"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "SFPL",
+   "metadata": {},
+   "source": [
+    "## 2. Simple Classifier\n",
+    "\n",
+    "This example illustrates how to configure a training runner with **PROTOplast** and **Ray**.\n",
+    "\n",
+    "- `LinearClassifier`: a simple baseline model that can be swapped with a custom implementation\n",
+    "- `Dcl`: the dataset object for training, imported from `protoplast.scrna.anndata.torch_dataloader`\n",
+    "  - Defined as a subclass of `DistributedAnnDataset`, customized for cell line classification tasks\n",
+    "- `[\"num_genes\", \"num_classes\"]`: arguments that specify the model’s input and output dimensions\n",
+    "- `cell_line_metadata_cb`: a callback function that attaches dataset-specific metadata, such as cell line labels and class counts"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 3,
+   "id": "BYtC",
+   "metadata": {
+    "scrolled": true
+   },
+   "outputs": [
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "2025-09-29 15:48:10,463\tINFO worker.py:1951 -- Started a local Ray instance.\n",
+      "2025-09-29 15:48:10,692\tINFO packaging.py:588 -- Creating a file package for local module '/mnt/hdd1/dung/protoplast-ml-example'.\n",
+      "2025-09-29 15:48:10,823\tWARNING packaging.py:430 -- File /mnt/hdd1/dung/protoplast-ml-example/.git/modules/submodules/SIMS/objects/pack/pack-682433dc4cf8becc2b44606f464dde9068565261.pack is very large (34.70MiB). Consider adding this file to the 'excludes' list to skip uploading it: `ray.init(..., runtime_env={'excludes': ['/mnt/hdd1/dung/protoplast-ml-example/.git/modules/submodules/SIMS/objects/pack/pack-682433dc4cf8becc2b44606f464dde9068565261.pack']})`\n",
+      "2025-09-29 15:48:11,056\tINFO packaging.py:380 -- Pushing file package 'gcs://_ray_pkg_dbb4b323aeef291d.zip' (69.15MiB) to Ray cluster...\n",
+      "2025-09-29 15:48:11,561\tINFO packaging.py:393 -- Successfully pushed file package 'gcs://_ray_pkg_dbb4b323aeef291d.zip'.\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "CPU times: user 794 ms, sys: 726 ms, total: 1.52 s\n",
+      "Wall time: 8.63 s\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "\u001b[33m(raylet)\u001b[0m \u001b[1m\u001b[33mwarning\u001b[39m\u001b[0m\u001b[1m:\u001b[0m \u001b[1m`VIRTUAL_ENV=/mnt/hdd1/dung/protoplast-ml-example/.venv` does not match the project environment path `.venv` and will be ignored; use `--active` to target the active environment instead\u001b[0m\n",
+      "\u001b[33m(raylet)\u001b[0m Using CPython \u001b[36m3.11.13\u001b[39m\n",
+      "\u001b[33m(raylet)\u001b[0m Creating virtual environment at: \u001b[36m.venv\u001b[39m\n",
+      "\u001b[33m(raylet)\u001b[0m \u001b[2mInstalled \u001b[1m296 packages\u001b[0m \u001b[2min 348ms\u001b[0m\u001b[0m\n",
+      "\u001b[33m(raylet)\u001b[0m \u001b[1m\u001b[33mwarning\u001b[39m\u001b[0m\u001b[1m:\u001b[0m \u001b[1m`VIRTUAL_ENV=/mnt/hdd1/dung/protoplast-ml-example/.venv` does not match the project environment path `.venv` and will be ignored; use `--active` to target the active environment instead\u001b[0m\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "\u001b[36m(TrainTrainable pid=3295631)\u001b[0m ✓ Applied AnnDataFileManager patch, AnnData cannot be imported after the patch!\n",
+      "\u001b[36m(TrainTrainable pid=3295631)\u001b[0m ✓ Applied AnnDataFileManager patch, AnnData cannot be imported after the patch!\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "\u001b[33m(raylet)\u001b[0m \u001b[1m\u001b[33mwarning\u001b[39m\u001b[0m\u001b[1m:\u001b[0m \u001b[1m`VIRTUAL_ENV=/mnt/hdd1/dung/protoplast-ml-example/.venv` does not match the project environment path `.venv` and will be ignored; use `--active` to target the active environment instead\u001b[0m\n",
+      "\u001b[36m(RayTrainWorker pid=3296882)\u001b[0m Setting up process group for: env:// [rank=0, world_size=1]\n",
+      "\u001b[36m(TorchTrainer pid=3295631)\u001b[0m Started distributed worker processes: \n",
+      "\u001b[36m(TorchTrainer pid=3295631)\u001b[0m - (node_id=6322a982fe7253de9609b5bb9b18d97905853f8cf5146fdbd78447c3, ip=192.168.1.226, pid=3296882) world_rank=0, local_rank=0, node_rank=0\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "\u001b[36m(RayTrainWorker pid=3296882)\u001b[0m ✓ Applied AnnDataFileManager patch, AnnData cannot be imported after the patch!\n",
+      "\u001b[36m(RayTrainWorker pid=3296882)\u001b[0m ✓ Applied AnnDataFileManager patch, AnnData cannot be imported after the patch!\n",
+      "\u001b[36m(RayTrainWorker pid=3296882)\u001b[0m =========Starting the training on 0 with num threads: 4=========\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "\u001b[36m(RayTrainWorker pid=3296882)\u001b[0m 💡 Tip: For seamless cloud uploads and versioning, try installing [litmodels](https://pypi.org/project/litmodels/) to enable LitModelCheckpoint, which syncs automatically with the Lightning model registry.\n",
+      "\u001b[36m(RayTrainWorker pid=3296882)\u001b[0m GPU available: True (cuda), used: True\n",
+      "\u001b[36m(RayTrainWorker pid=3296882)\u001b[0m TPU available: False, using: 0 TPU cores\n",
+      "\u001b[36m(RayTrainWorker pid=3296882)\u001b[0m HPU available: False, using: 0 HPUs\n",
+      "\u001b[36m(RayTrainWorker pid=3296882)\u001b[0m /tmp/ray/session_2025-09-29_15-48-06_722491_3287714/runtime_resources/working_dir_files/_ray_pkg_dbb4b323aeef291d/.venv/lib/python3.11/site-packages/lightning/fabric/plugins/environments/slurm.py:204: The `srun` command is available on your system but is not used. HINT: If your intention is to run Lightning on SLURM, prepend your python command with `srun` like so: srun python3 /mnt/hdd1/dung/protoplast-ml-example/.venv/lib/pyth ...\n",
+      "\u001b[36m(RayTrainWorker pid=3296882)\u001b[0m You are using a CUDA device ('NVIDIA GeForce RTX 3080') that has Tensor Cores. To properly utilize them, you should set `torch.set_float32_matmul_precision('medium' | 'high')` which will trade-off precision for performance. For more details, read https://pytorch.org/docs/stable/generated/torch.set_float32_matmul_precision.html#torch.set_float32_matmul_precision\n",
+      "\u001b[36m(RayTrainWorker pid=3296882)\u001b[0m LOCAL_RANK: 0 - CUDA_VISIBLE_DEVICES: [0]\n",
+      "\u001b[36m(RayTrainWorker pid=3296882)\u001b[0m \n",
+      "\u001b[36m(RayTrainWorker pid=3296882)\u001b[0m   | Name    | Type             | Params | Mode \n",
+      "\u001b[36m(RayTrainWorker pid=3296882)\u001b[0m -----------------------------------------------------\n",
+      "\u001b[36m(RayTrainWorker pid=3296882)\u001b[0m 0 | model   | Linear           | 3.1 M  | train\n",
+      "\u001b[36m(RayTrainWorker pid=3296882)\u001b[0m 1 | loss_fn | CrossEntropyLoss | 0      | train\n",
+      "\u001b[36m(RayTrainWorker pid=3296882)\u001b[0m -----------------------------------------------------\n",
+      "\u001b[36m(RayTrainWorker pid=3296882)\u001b[0m 3.1 M     Trainable params\n",
+      "\u001b[36m(RayTrainWorker pid=3296882)\u001b[0m 0         Non-trainable params\n",
+      "\u001b[36m(RayTrainWorker pid=3296882)\u001b[0m 3.1 M     Total params\n",
+      "\u001b[36m(RayTrainWorker pid=3296882)\u001b[0m 12.542    Total estimated model params size (MB)\n",
+      "\u001b[36m(RayTrainWorker pid=3296882)\u001b[0m 2         Modules in train mode\n",
+      "\u001b[36m(RayTrainWorker pid=3296882)\u001b[0m 0         Modules in eval mode\n",
+      "\u001b[36m(RayTrainWorker pid=3296882)\u001b[0m /tmp/ray/session_2025-09-29_15-48-06_722491_3287714/runtime_resources/working_dir_files/_ray_pkg_dbb4b323aeef291d/.venv/lib/python3.11/site-packages/torch/distributed/distributed_c10d.py:4807: UserWarning: No device id is provided via `init_process_group` or `barrier `. Using the current device set by the user. \n",
+      "\u001b[36m(RayTrainWorker pid=3296882)\u001b[0m   warnings.warn(  # warn only once\n",
+      "\u001b[36m(RayTrainWorker pid=3296882)\u001b[0m /tmp/ray/session_2025-09-29_15-48-06_722491_3287714/runtime_resources/working_dir_files/_ray_pkg_dbb4b323aeef291d/.venv/lib/python3.11/site-packages/lightning/pytorch/utilities/data.py:123: Your `IterableDataset` has `__len__` defined. In combination with multi-process data loading (when num_workers > 1), `__len__` could be inaccurate if each worker is not configured independently to avoid having duplicate data.\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Sanity Checking: |          | 0/? [00:00<?, ?it/s]\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "\u001b[36m(RayTrainWorker pid=3296882)\u001b[0m /tmp/ray/session_2025-09-29_15-48-06_722491_3287714/runtime_resources/working_dir_files/_ray_pkg_dbb4b323aeef291d/submodules/protoplast/src/protoplast/scrna/anndata/torch_dataloader.py:130: UserWarning: Sparse CSR tensor support is in beta state. If you miss a functionality in the sparse tensor support, please submit a feature request to https://github.com/pytorch/pytorch/issues. (Triggered internally at /pytorch/aten/src/ATen/SparseCsrTensorImpl.cpp:53.)\n",
+      "\u001b[36m(RayTrainWorker pid=3296882)\u001b[0m   return torch.sparse_csr_tensor(\n",
+      "\u001b[36m(RayTrainWorker pid=3296882)\u001b[0m /tmp/ray/session_2025-09-29_15-48-06_722491_3287714/runtime_resources/working_dir_files/_ray_pkg_dbb4b323aeef291d/.venv/lib/python3.11/site-packages/torch/multiprocessing/reductions.py:473: UserWarning: Sparse CSR tensor support is in beta state. If you miss a functionality in the sparse tensor support, please submit a feature request to https://github.com/pytorch/pytorch/issues. (Triggered internally at /pytorch/aten/src/ATen/SparseCsrTensorImpl.cpp:53.)\n",
+      "\u001b[36m(RayTrainWorker pid=3296882)\u001b[0m   return torch.sparse_compressed_tensor(\n",
+      "\u001b[36m(RayTrainWorker pid=3296882)\u001b[0m /tmp/ray/session_2025-09-29_15-48-06_722491_3287714/runtime_resources/working_dir_files/_ray_pkg_dbb4b323aeef291d/submodules/protoplast/src/protoplast/scrna/anndata/torch_dataloader.py:130: UserWarning: Sparse CSR tensor support is in beta state. If you miss a functionality in the sparse tensor support, please submit a feature request to https://github.com/pytorch/pytorch/issues. (Triggered internally at /pytorch/aten/src/ATen/SparseCsrTensorImpl.cpp:53.)\n",
+      "\u001b[36m(RayTrainWorker pid=3296882)\u001b[0m   return torch.sparse_csr_tensor(\n",
+      "\u001b[36m(RayTrainWorker pid=3296882)\u001b[0m /tmp/ray/session_2025-09-29_15-48-06_722491_3287714/runtime_resources/working_dir_files/_ray_pkg_dbb4b323aeef291d/submodules/protoplast/src/protoplast/scrna/anndata/torch_dataloader.py:130: UserWarning: Sparse CSR tensor support is in beta state. If you miss a functionality in the sparse tensor support, please submit a feature request to https://github.com/pytorch/pytorch/issues. (Triggered internally at /pytorch/aten/src/ATen/SparseCsrTensorImpl.cpp:53.)\n",
+      "\u001b[36m(RayTrainWorker pid=3296882)\u001b[0m   return torch.sparse_csr_tensor(\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Sanity Checking DataLoader 0:   0%|          | 0/2 [00:00<?, ?it/s]\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "\u001b[36m(RayTrainWorker pid=3296882)\u001b[0m /tmp/ray/session_2025-09-29_15-48-06_722491_3287714/runtime_resources/working_dir_files/_ray_pkg_dbb4b323aeef291d/.venv/lib/python3.11/site-packages/lightning/pytorch/trainer/connectors/logger_connector/result.py:434: It is recommended to use `self.log('val_acc', ..., sync_dist=True)` when logging on epoch level in distributed setting to accumulate the metric across devices.\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "                                                                           \n",
+      "Epoch 0:   0%|          | 0/4160 [00:00<?, ?it/s] \n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "\u001b[36m(RayTrainWorker pid=3296882)\u001b[0m /tmp/ray/session_2025-09-29_15-48-06_722491_3287714/runtime_resources/working_dir_files/_ray_pkg_dbb4b323aeef291d/submodules/protoplast/src/protoplast/scrna/anndata/torch_dataloader.py:130: UserWarning: Sparse CSR tensor support is in beta state. If you miss a functionality in the sparse tensor support, please submit a feature request to https://github.com/pytorch/pytorch/issues. (Triggered internally at /pytorch/aten/src/ATen/SparseCsrTensorImpl.cpp:53.)\n",
+      "\u001b[36m(RayTrainWorker pid=3296882)\u001b[0m   return torch.sparse_csr_tensor(\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Epoch 0:   0%|          | 1/4160 [00:29<33:58:56,  0.03it/s, v_num=0, train_loss=3.950]\n",
+      "Epoch 0:   0%|          | 3/4160 [00:31<12:11:50,  0.09it/s, v_num=0, train_loss=3.050]\n",
+      ".\n",
+      ".\n",
+      ".\n",
+      "Epoch 0: 100%|█████████▉| 4147/4160 [05:22<00:01, 12.86it/s, v_num=0, train_loss=0.146]\n",
+      "Epoch 0: 100%|█████████▉| 4148/4160 [05:22<00:00, 12.86it/s, v_num=0, train_loss=0.154]\n",
+      "Epoch 0: 100%|█████████▉| 4153/4160 [05:22<00:00, 12.87it/s, v_num=0, train_loss=0.0986]\n",
+      "Epoch 0: 100%|█████████▉| 4154/4160 [05:22<00:00, 12.88it/s, v_num=0, train_loss=0.0893]\n",
+      "Epoch 0: 100%|█████████▉| 4159/4160 [05:22<00:00, 12.89it/s, v_num=0, train_loss=0.108] \n",
+      "Epoch 0: 100%|██████████| 4160/4160 [05:22<00:00, 12.89it/s, v_num=0, train_loss=0.130]\n",
+      "\u001b[36m(RayTrainWorker pid=3296882)\u001b[0m \n",
+      "Validation: |          | 0/? [00:00<?, ?it/s]\u001b[A\n",
+      "\u001b[36m(RayTrainWorker pid=3296882)\u001b[0m \n",
+      "Validation:   0%|          | 0/1024 [00:00<?, ?it/s]\u001b[A\n",
+      "Validation DataLoader 0:   0%|          | 0/1024 [00:00<?, ?it/s]\u001b[A\n",
+      "Validation DataLoader 0:   0%|          | 1/1024 [00:00<00:05, 192.22it/s]\u001b[A\n",
+      "\u001b[36m(RayTrainWorker pid=3296882)\u001b[0m \n",
+      "Validation DataLoader 0:   0%|          | 2/1024 [00:00<07:01,  2.42it/s] \u001b[A\n",
+      "Validation DataLoader 0:   0%|          | 3/1024 [00:00<04:47,  3.55it/s]\u001b[A\n",
+      "Validation DataLoader 0:   0%|          | 4/1024 [00:00<03:42,  4.59it/s]\u001b[A\n",
+      "Validation DataLoader 0:   0%|          | 5/1024 [00:00<03:02,  5.60it/s]\u001b[A\n",
+      "Validation DataLoader 0:   1%|          | 6/1024 [00:00<02:35,  6.54it/s]\u001b[A\n",
+      "\u001b[36m(RayTrainWorker pid=3296882)\u001b[0m \n",
+      "Validation DataLoader 0:   1%|          | 7/1024 [00:00<02:16,  7.45it/s]\u001b[A\n",
+      ".\n",
+      ".\n",
+      ".\n",
+      "Validation DataLoader 0: 100%|█████████▉| 1019/1024 [00:59<00:00, 17.04it/s]\u001b[A\n",
+      "\u001b[36m(RayTrainWorker pid=3296882)\u001b[0m \n",
+      "Validation DataLoader 0: 100%|█████████▉| 1020/1024 [00:59<00:00, 17.05it/s]\u001b[A\n",
+      "Validation DataLoader 0: 100%|█████████▉| 1021/1024 [00:59<00:00, 17.06it/s]\u001b[A\n",
+      "Validation DataLoader 0: 100%|█████████▉| 1022/1024 [00:59<00:00, 17.07it/s]\u001b[A\n",
+      "Validation DataLoader 0: 100%|█████████▉| 1023/1024 [00:59<00:00, 17.08it/s]\u001b[A\n",
+      "Validation DataLoader 0: 100%|██████████| 1024/1024 [00:59<00:00, 17.09it/s]\u001b[A\n",
+      "Epoch 0: 100%|██████████| 4160/4160 [06:50<00:00, 10.12it/s, v_num=0, train_loss=0.130]\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "\u001b[36m(RayTrainWorker pid=3296882)\u001b[0m Checkpoint successfully created at: Checkpoint(filesystem=local, path=/home/dtran/protoplast_results/TorchTrainer_2025-09-29_15-48-41/TorchTrainer_c5f9c_00000_0_2025-09-29_15-48-43/checkpoint_000000)\n",
+      "\u001b[36m(RayTrainWorker pid=3296882)\u001b[0m `Trainer.fit` stopped: `max_epochs=1` reached.\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Epoch 0: 100%|██████████| 4160/4160 [06:51<00:00, 10.12it/s, v_num=0, train_loss=0.130]\n",
+      "Epoch 0: 100%|██████████| 4160/4160 [06:51<00:00, 10.12it/s, v_num=0, train_loss=0.130]\n"
+     ]
+    }
+   ],
+   "source": [
+    "%%time\n",
+    "LinearClassifier_trainer = RayTrainRunner(\n",
+    "    LinearClassifier,  # replace with your own model\n",
+    "    Dcl,  # replace with your own Dataset\n",
+    "    [\"num_genes\", \"num_classes\"],  # change according to what you need for your model\n",
+    "    cell_line_metadata_cb,  # include data you need for your dataset\n",
+    ")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "f8c2c38b",
+   "metadata": {},
+   "source": [
+    "On a machine with **1 GPU (NVIDIA GeForce RTX 3080 - 12 GiB)**, **96 CPUs**, and **125 GiB RAM**, running `LinearClassifier_trainer.train()` completed in approximately **9 minutes**."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 4,
+   "id": "RGSE",
+   "metadata": {
+    "scrolled": true
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Setting thread_per_worker to half of the available CPUs capped at 4\n",
+      "Using 1 workers with {'CPU': 4} each\n",
+      "=========Length of val_split 65 length of test_split 0 length of train_split 262\n",
+      "=========Length of after dropping remainder val_split 64 length of test_split 0 length of train_split 260\n",
+      "Data splitting time: 26.24 seconds\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "2025-09-29 15:48:41,802\tINFO tune.py:616 -- [output] This uses the legacy output and progress reporter, as Jupyter notebooks are not supported by the new engine, yet. For more information, please see https://github.com/ray-project/ray/issues/36949\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Spawning Ray worker and initiating distributed training\n",
+      "== Status ==\n",
+      "Current time: 2025-09-29 15:48:43 (running for 00:00:00.16)\n",
+      "Using FIFO scheduling algorithm.\n",
+      "Logical resource usage: 0/96 CPUs, 0/1 GPUs (0.0/1.0 accelerator_type:G)\n",
+      "Result logdir: /tmp/ray/session_2025-09-29_15-48-06_722491_3287714/artifacts/2025-09-29_15-48-41/TorchTrainer_2025-09-29_15-48-41/driver_artifacts\n",
+      "Number of trials: 1/1 (1 PENDING)\n",
+      "\n",
+      "\n",
+      "== Status ==\n",
+      "Current time: 2025-09-29 15:49:09 (running for 00:00:25.33)\n",
+      "Using FIFO scheduling algorithm.\n",
+      "Logical resource usage: 5.0/96 CPUs, 1.0/1 GPUs (0.0/1.0 accelerator_type:G)\n",
+      "Result logdir: /tmp/ray/session_2025-09-29_15-48-06_722491_3287714/artifacts/2025-09-29_15-48-41/TorchTrainer_2025-09-29_15-48-41/driver_artifacts\n",
+      "Number of trials: 1/1 (1 RUNNING)\n",
+      "\n",
+      "\n",
+      "== Status ==\n",
+      "Current time: 2025-09-29 15:56:36 (running for 00:07:53.21)\n",
+      "Using FIFO scheduling algorithm.\n",
+      "Logical resource usage: 5.0/96 CPUs, 1.0/1 GPUs (0.0/1.0 accelerator_type:G)\n",
+      "Result logdir: /tmp/ray/session_2025-09-29_15-48-06_722491_3287714/artifacts/2025-09-29_15-48-41/TorchTrainer_2025-09-29_15-48-41/driver_artifacts\n",
+      "Number of trials: 1/1 (1 RUNNING)\n",
+      "\n",
+      "\n",
+      "== Status ==\n",
+      "Current time: 2025-09-29 15:56:41 (running for 00:07:58.23)\n",
+      "Using FIFO scheduling algorithm.\n",
+      "Logical resource usage: 5.0/96 CPUs, 1.0/1 GPUs (0.0/1.0 accelerator_type:G)\n",
+      "Result logdir: /tmp/ray/session_2025-09-29_15-48-06_722491_3287714/artifacts/2025-09-29_15-48-41/TorchTrainer_2025-09-29_15-48-41/driver_artifacts\n",
+      "Number of trials: 1/1 (1 RUNNING)\n",
+      "\n",
+      "\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "2025-09-29 15:56:42,595\tINFO tune.py:1009 -- Wrote the latest version of all result files and experiment state to '/home/dtran/protoplast_results/TorchTrainer_2025-09-29_15-48-41' in 0.0100s.\n",
+      "2025-09-29 15:56:42,600\tINFO tune.py:1041 -- Total run time: 480.80 seconds (478.89 seconds for the tuning loop).\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "== Status ==\n",
+      "Current time: 2025-09-29 15:56:42 (running for 00:07:58.90)\n",
+      "Using FIFO scheduling algorithm.\n",
+      "Logical resource usage: 5.0/96 CPUs, 1.0/1 GPUs (0.0/1.0 accelerator_type:G)\n",
+      "Result logdir: /tmp/ray/session_2025-09-29_15-48-06_722491_3287714/artifacts/2025-09-29_15-48-41/TorchTrainer_2025-09-29_15-48-41/driver_artifacts\n",
+      "Number of trials: 1/1 (1 TERMINATED)\n",
+      "\n",
+      "\n",
+      "CPU times: user 27.2 s, sys: 6.66 s, total: 33.8 s\n",
+      "Wall time: 8min 29s\n"
+     ]
+    }
+   ],
+   "source": [
+    "%%time\n",
+    "LinearClassifier_trainer.train(\n",
+    "    file_paths,\n",
+    "    batch_size,  # 2000\n",
+    "    test_size,  # 0.0\n",
+    "    val_size,  # 0.2\n",
+    ")\n",
+    "ray.shutdown()"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "Kclp",
+   "metadata": {},
+   "source": [
+    "## 3. SIMS: Scalable, Interpretable Models for Cell Annotation of large scale single-cell RNA-seq data\n",
+    "**SIMS** is a pipeline designed to build interpretable and accurate classifiers for identifying any target in single-cell RNA sequencing (scRNA-seq) data.  \n",
+    "- The core SIMS model is based on a **sequential transformer**, a specialized transformer architecture built for large-scale tabular datasets. \n",
+    "- SIMS provides a framework for **cell type annotation**: it trains on labeled single-cell data and predicts cell type labels for new, unlabeled cells. \n",
+    "- It leverages the **TabNet** deep learning model, which automatically selects the most informative genes for each prediction, ensuring results that are both **accurate** and **interpretable**.  \n",
+    "For implementation details and source code, see the [SIMS GitHub repository](https://github.com/braingeneers/SIMS/tree/main)."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "emfo",
+   "metadata": {},
+   "source": [
+    "### SIMS Metadata Callback\n",
+    "This callback (`sims_metadata_cb`) extracts key information from the AnnData object to configure the SIMS model.\n",
+    "- `input_dim`: the number of genes (features) in the dataset.\n",
+    "- `cell_lines`: list of unique cell line categories.\n",
+    "- `output_dim`: the number of distinct classes (cell lines) to be predicted."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 5,
+   "id": "Hstk",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "def sims_metadata_cb(ad: anndata.AnnData, metadata: dict):\n",
+    "    metadata[\"num_genes\"] = ad.var.shape[0]\n",
+    "    metadata[\"input_dim\"] = metadata[\"num_genes\"]\n",
+    "    metadata[\"cell_lines\"] = ad.obs[\"cell_line\"].cat.categories.to_list()\n",
+    "    metadata[\"num_classes\"] = len(metadata[\"cell_lines\"])\n",
+    "    metadata[\"output_dim\"] = metadata[\"num_classes\"]"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "nWHF",
+   "metadata": {},
+   "source": [
+    "### Training the SIMS Classifier\n",
+    "\n",
+    "- The **SIMSClassifier** model is initialized with the dataset (`Dcl`), while essential arguments (`input_dim`, `output_dim`) are supplied through the `sims_metadata_cb` callback \n",
+    "- Training is distributed using **RayDDPStrategy**, with `find_unused_parameters=True` enabled to ensure proper handling of layers that may not be active in every forward pass\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 6,
+   "id": "iLit",
+   "metadata": {
+    "scrolled": true
+   },
+   "outputs": [
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "2025-09-29 15:57:36,769\tINFO worker.py:1951 -- Started a local Ray instance.\n",
+      "2025-09-29 15:57:38,275\tINFO packaging.py:588 -- Creating a file package for local module '/mnt/hdd1/dung/protoplast-ml-example'.\n",
+      "2025-09-29 15:57:38,490\tWARNING packaging.py:430 -- File /mnt/hdd1/dung/protoplast-ml-example/.git/modules/submodules/SIMS/objects/pack/pack-682433dc4cf8becc2b44606f464dde9068565261.pack is very large (34.70MiB). Consider adding this file to the 'excludes' list to skip uploading it: `ray.init(..., runtime_env={'excludes': ['/mnt/hdd1/dung/protoplast-ml-example/.git/modules/submodules/SIMS/objects/pack/pack-682433dc4cf8becc2b44606f464dde9068565261.pack']})`\n",
+      "2025-09-29 15:57:38,726\tINFO packaging.py:380 -- Pushing file package 'gcs://_ray_pkg_0bc7f6254ceca816.zip' (69.14MiB) to Ray cluster...\n",
+      "2025-09-29 15:57:39,243\tINFO packaging.py:393 -- Successfully pushed file package 'gcs://_ray_pkg_0bc7f6254ceca816.zip'.\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "CPU times: user 746 ms, sys: 760 ms, total: 1.51 s\n",
+      "Wall time: 10.7 s\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "\u001b[33m(raylet)\u001b[0m \u001b[1m\u001b[33mwarning\u001b[39m\u001b[0m\u001b[1m:\u001b[0m \u001b[1m`VIRTUAL_ENV=/mnt/hdd1/dung/protoplast-ml-example/.venv` does not match the project environment path `.venv` and will be ignored; use `--active` to target the active environment instead\u001b[0m\n",
+      "\u001b[33m(raylet)\u001b[0m Using CPython \u001b[36m3.11.13\u001b[39m\n",
+      "\u001b[33m(raylet)\u001b[0m Creating virtual environment at: \u001b[36m.venv\u001b[39m\n",
+      "\u001b[33m(raylet)\u001b[0m \u001b[2mInstalled \u001b[1m296 packages\u001b[0m \u001b[2min 322ms\u001b[0m\u001b[0m\n",
+      "\u001b[33m(raylet)\u001b[0m \u001b[1m\u001b[33mwarning\u001b[39m\u001b[0m\u001b[1m:\u001b[0m \u001b[1m`VIRTUAL_ENV=/mnt/hdd1/dung/protoplast-ml-example/.venv` does not match the project environment path `.venv` and will be ignored; use `--active` to target the active environment instead\u001b[0m\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "\u001b[36m(TrainTrainable pid=3309981)\u001b[0m ✓ Applied AnnDataFileManager patch, AnnData cannot be imported after the patch!\n",
+      "\u001b[36m(TrainTrainable pid=3309981)\u001b[0m ✓ Applied AnnDataFileManager patch, AnnData cannot be imported after the patch!\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "\u001b[33m(raylet)\u001b[0m \u001b[1m\u001b[33mwarning\u001b[39m\u001b[0m\u001b[1m:\u001b[0m \u001b[1m`VIRTUAL_ENV=/mnt/hdd1/dung/protoplast-ml-example/.venv` does not match the project environment path `.venv` and will be ignored; use `--active` to target the active environment instead\u001b[0m\n",
+      "\u001b[36m(RayTrainWorker pid=3311122)\u001b[0m Setting up process group for: env:// [rank=0, world_size=1]\n",
+      "\u001b[36m(TorchTrainer pid=3309981)\u001b[0m Started distributed worker processes: \n",
+      "\u001b[36m(TorchTrainer pid=3309981)\u001b[0m - (node_id=b7aa76930fb0b23923b4c09f1ac8ae73d51c8f7724cf1b4cacb7631c, ip=192.168.1.226, pid=3311122) world_rank=0, local_rank=0, node_rank=0\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "\u001b[36m(RayTrainWorker pid=3311122)\u001b[0m ✓ Applied AnnDataFileManager patch, AnnData cannot be imported after the patch!\n",
+      "\u001b[36m(RayTrainWorker pid=3311122)\u001b[0m ✓ Applied AnnDataFileManager patch, AnnData cannot be imported after the patch!\n",
+      "\u001b[36m(RayTrainWorker pid=3311122)\u001b[0m =========Starting the training on 0 with num threads: 4=========\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "\u001b[36m(RayTrainWorker pid=3311122)\u001b[0m 💡 Tip: For seamless cloud uploads and versioning, try installing [litmodels](https://pypi.org/project/litmodels/) to enable LitModelCheckpoint, which syncs automatically with the Lightning model registry.\n",
+      "\u001b[36m(RayTrainWorker pid=3311122)\u001b[0m GPU available: True (cuda), used: True\n",
+      "\u001b[36m(RayTrainWorker pid=3311122)\u001b[0m TPU available: False, using: 0 TPU cores\n",
+      "\u001b[36m(RayTrainWorker pid=3311122)\u001b[0m HPU available: False, using: 0 HPUs\n",
+      "\u001b[36m(RayTrainWorker pid=3311122)\u001b[0m /tmp/ray/session_2025-09-29_15-57-32_695037_3287714/runtime_resources/working_dir_files/_ray_pkg_0bc7f6254ceca816/.venv/lib/python3.11/site-packages/lightning/fabric/plugins/environments/slurm.py:204: The `srun` command is available on your system but is not used. HINT: If your intention is to run Lightning on SLURM, prepend your python command with `srun` like so: srun python3 /mnt/hdd1/dung/protoplast-ml-example/.venv/lib/pyth ...\n",
+      "\u001b[36m(RayTrainWorker pid=3311122)\u001b[0m You are using a CUDA device ('NVIDIA GeForce RTX 3080') that has Tensor Cores. To properly utilize them, you should set `torch.set_float32_matmul_precision('medium' | 'high')` which will trade-off precision for performance. For more details, read https://pytorch.org/docs/stable/generated/torch.set_float32_matmul_precision.html#torch.set_float32_matmul_precision\n",
+      "\u001b[36m(RayTrainWorker pid=3311122)\u001b[0m LOCAL_RANK: 0 - CUDA_VISIBLE_DEVICES: [0]\n",
+      "\u001b[36m(RayTrainWorker pid=3311122)\u001b[0m \n",
+      "\u001b[36m(RayTrainWorker pid=3311122)\u001b[0m   | Name          | Type             | Params | Mode \n",
+      "\u001b[36m(RayTrainWorker pid=3311122)\u001b[0m -----------------------------------------------------------\n",
+      "\u001b[36m(RayTrainWorker pid=3311122)\u001b[0m 0 | network       | TabNet           | 2.3 M  | train\n",
+      "\u001b[36m(RayTrainWorker pid=3311122)\u001b[0m 1 | train_metrics | MetricCollection | 0      | train\n",
+      "\u001b[36m(RayTrainWorker pid=3311122)\u001b[0m 2 | val_metrics   | MetricCollection | 0      | train\n",
+      "\u001b[36m(RayTrainWorker pid=3311122)\u001b[0m   | other params  | n/a              | 1      | n/a  \n",
+      "\u001b[36m(RayTrainWorker pid=3311122)\u001b[0m -----------------------------------------------------------\n",
+      "\u001b[36m(RayTrainWorker pid=3311122)\u001b[0m 2.3 M     Trainable params\n",
+      "\u001b[36m(RayTrainWorker pid=3311122)\u001b[0m 0         Non-trainable params\n",
+      "\u001b[36m(RayTrainWorker pid=3311122)\u001b[0m 2.3 M     Total params\n",
+      "\u001b[36m(RayTrainWorker pid=3311122)\u001b[0m 9.054     Total estimated model params size (MB)\n",
+      "\u001b[36m(RayTrainWorker pid=3311122)\u001b[0m 119       Modules in train mode\n",
+      "\u001b[36m(RayTrainWorker pid=3311122)\u001b[0m 0         Modules in eval mode\n",
+      "\u001b[36m(RayTrainWorker pid=3311122)\u001b[0m /tmp/ray/session_2025-09-29_15-57-32_695037_3287714/runtime_resources/working_dir_files/_ray_pkg_0bc7f6254ceca816/.venv/lib/python3.11/site-packages/torch/distributed/distributed_c10d.py:4807: UserWarning: No device id is provided via `init_process_group` or `barrier `. Using the current device set by the user. \n",
+      "\u001b[36m(RayTrainWorker pid=3311122)\u001b[0m   warnings.warn(  # warn only once\n",
+      "\u001b[36m(RayTrainWorker pid=3311122)\u001b[0m /tmp/ray/session_2025-09-29_15-57-32_695037_3287714/runtime_resources/working_dir_files/_ray_pkg_0bc7f6254ceca816/.venv/lib/python3.11/site-packages/lightning/pytorch/utilities/data.py:123: Your `IterableDataset` has `__len__` defined. In combination with multi-process data loading (when num_workers > 1), `__len__` could be inaccurate if each worker is not configured independently to avoid having duplicate data.\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Sanity Checking: |          | 0/? [00:00<?, ?it/s]\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "\u001b[36m(RayTrainWorker pid=3311122)\u001b[0m /tmp/ray/session_2025-09-29_15-57-32_695037_3287714/runtime_resources/working_dir_files/_ray_pkg_0bc7f6254ceca816/submodules/protoplast/src/protoplast/scrna/anndata/torch_dataloader.py:130: UserWarning: Sparse CSR tensor support is in beta state. If you miss a functionality in the sparse tensor support, please submit a feature request to https://github.com/pytorch/pytorch/issues. (Triggered internally at /pytorch/aten/src/ATen/SparseCsrTensorImpl.cpp:53.)\n",
+      "\u001b[36m(RayTrainWorker pid=3311122)\u001b[0m   return torch.sparse_csr_tensor(\n",
+      "\u001b[36m(RayTrainWorker pid=3311122)\u001b[0m /tmp/ray/session_2025-09-29_15-57-32_695037_3287714/runtime_resources/working_dir_files/_ray_pkg_0bc7f6254ceca816/submodules/protoplast/src/protoplast/scrna/anndata/torch_dataloader.py:130: UserWarning: Sparse CSR tensor support is in beta state. If you miss a functionality in the sparse tensor support, please submit a feature request to https://github.com/pytorch/pytorch/issues. (Triggered internally at /pytorch/aten/src/ATen/SparseCsrTensorImpl.cpp:53.)\n",
+      "\u001b[36m(RayTrainWorker pid=3311122)\u001b[0m   return torch.sparse_csr_tensor(\n",
+      "\u001b[36m(RayTrainWorker pid=3311122)\u001b[0m /tmp/ray/session_2025-09-29_15-57-32_695037_3287714/runtime_resources/working_dir_files/_ray_pkg_0bc7f6254ceca816/.venv/lib/python3.11/site-packages/torch/multiprocessing/reductions.py:473: UserWarning: Sparse CSR tensor support is in beta state. If you miss a functionality in the sparse tensor support, please submit a feature request to https://github.com/pytorch/pytorch/issues. (Triggered internally at /pytorch/aten/src/ATen/SparseCsrTensorImpl.cpp:53.)\n",
+      "\u001b[36m(RayTrainWorker pid=3311122)\u001b[0m   return torch.sparse_compressed_tensor(\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Sanity Checking DataLoader 0:   0%|          | 0/2 [00:00<?, ?it/s]\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "\u001b[36m(RayTrainWorker pid=3311122)\u001b[0m /tmp/ray/session_2025-09-29_15-57-32_695037_3287714/runtime_resources/working_dir_files/_ray_pkg_0bc7f6254ceca816/submodules/protoplast/src/protoplast/scrna/anndata/torch_dataloader.py:130: UserWarning: Sparse CSR tensor support is in beta state. If you miss a functionality in the sparse tensor support, please submit a feature request to https://github.com/pytorch/pytorch/issues. (Triggered internally at /pytorch/aten/src/ATen/SparseCsrTensorImpl.cpp:53.)\n",
+      "\u001b[36m(RayTrainWorker pid=3311122)\u001b[0m   return torch.sparse_csr_tensor(\n",
+      "\u001b[36m(RayTrainWorker pid=3311122)\u001b[0m /tmp/ray/session_2025-09-29_15-57-32_695037_3287714/runtime_resources/working_dir_files/_ray_pkg_0bc7f6254ceca816/submodules/protoplast/src/protoplast/scrna/anndata/torch_dataloader.py:130: UserWarning: Sparse CSR tensor support is in beta state. If you miss a functionality in the sparse tensor support, please submit a feature request to https://github.com/pytorch/pytorch/issues. (Triggered internally at /pytorch/aten/src/ATen/SparseCsrTensorImpl.cpp:53.)\n",
+      "\u001b[36m(RayTrainWorker pid=3311122)\u001b[0m   return torch.sparse_csr_tensor(\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "                                                                           \n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "\u001b[36m(RayTrainWorker pid=3311122)\u001b[0m /tmp/ray/session_2025-09-29_15-57-32_695037_3287714/runtime_resources/working_dir_files/_ray_pkg_0bc7f6254ceca816/.venv/lib/python3.11/site-packages/lightning/pytorch/trainer/connectors/logger_connector/result.py:434: It is recommended to use `self.log('val/loss', ..., sync_dist=True)` when logging on epoch level in distributed setting to accumulate the metric across devices.\n",
+      "\u001b[36m(RayTrainWorker pid=3311122)\u001b[0m /tmp/ray/session_2025-09-29_15-57-32_695037_3287714/runtime_resources/working_dir_files/_ray_pkg_0bc7f6254ceca816/.venv/lib/python3.11/site-packages/lightning/pytorch/trainer/connectors/logger_connector/result.py:434: It is recommended to use `self.log('val/f1', ..., sync_dist=True)` when logging on epoch level in distributed setting to accumulate the metric across devices.\n",
+      "\u001b[36m(RayTrainWorker pid=3311122)\u001b[0m /tmp/ray/session_2025-09-29_15-57-32_695037_3287714/runtime_resources/working_dir_files/_ray_pkg_0bc7f6254ceca816/.venv/lib/python3.11/site-packages/lightning/pytorch/trainer/connectors/logger_connector/result.py:434: It is recommended to use `self.log('val/macro_acc', ..., sync_dist=True)` when logging on epoch level in distributed setting to accumulate the metric across devices.\n",
+      "\u001b[36m(RayTrainWorker pid=3311122)\u001b[0m /tmp/ray/session_2025-09-29_15-57-32_695037_3287714/runtime_resources/working_dir_files/_ray_pkg_0bc7f6254ceca816/.venv/lib/python3.11/site-packages/lightning/pytorch/trainer/connectors/logger_connector/result.py:434: It is recommended to use `self.log('val/micro_acc', ..., sync_dist=True)` when logging on epoch level in distributed setting to accumulate the metric across devices.\n",
+      "\u001b[36m(RayTrainWorker pid=3311122)\u001b[0m /tmp/ray/session_2025-09-29_15-57-32_695037_3287714/runtime_resources/working_dir_files/_ray_pkg_0bc7f6254ceca816/.venv/lib/python3.11/site-packages/lightning/pytorch/trainer/connectors/logger_connector/result.py:434: It is recommended to use `self.log('val/precision', ..., sync_dist=True)` when logging on epoch level in distributed setting to accumulate the metric across devices.\n",
+      "\u001b[36m(RayTrainWorker pid=3311122)\u001b[0m /tmp/ray/session_2025-09-29_15-57-32_695037_3287714/runtime_resources/working_dir_files/_ray_pkg_0bc7f6254ceca816/.venv/lib/python3.11/site-packages/lightning/pytorch/trainer/connectors/logger_connector/result.py:434: It is recommended to use `self.log('val/recall', ..., sync_dist=True)` when logging on epoch level in distributed setting to accumulate the metric across devices.\n",
+      "\u001b[36m(RayTrainWorker pid=3311122)\u001b[0m /tmp/ray/session_2025-09-29_15-57-32_695037_3287714/runtime_resources/working_dir_files/_ray_pkg_0bc7f6254ceca816/.venv/lib/python3.11/site-packages/lightning/pytorch/trainer/connectors/logger_connector/result.py:434: It is recommended to use `self.log('val/specificity', ..., sync_dist=True)` when logging on epoch level in distributed setting to accumulate the metric across devices.\n",
+      "\u001b[36m(RayTrainWorker pid=3311122)\u001b[0m /tmp/ray/session_2025-09-29_15-57-32_695037_3287714/runtime_resources/working_dir_files/_ray_pkg_0bc7f6254ceca816/.venv/lib/python3.11/site-packages/lightning/pytorch/trainer/connectors/logger_connector/result.py:434: It is recommended to use `self.log('val/weighted_acc', ..., sync_dist=True)` when logging on epoch level in distributed setting to accumulate the metric across devices.\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Epoch 0:   0%|          | 0/4160 [00:00<?, ?it/s] \n",
+      "Epoch 0:   0%|          | 1/4160 [00:24<27:53:00,  0.04it/s, v_num=0, train/loss_step=4.750]\n",
+      ".\n",
+      ".\n",
+      ".\n",
+      "Epoch 0: 100%|█████████▉| 4157/4160 [09:05<00:00,  7.62it/s, v_num=0, train/loss_step=0.382]\n",
+      "Epoch 0: 100%|█████████▉| 4158/4160 [09:05<00:00,  7.62it/s, v_num=0, train/loss_step=0.433]\n",
+      "Epoch 0: 100%|█████████▉| 4159/4160 [09:05<00:00,  7.62it/s, v_num=0, train/loss_step=0.520]\n",
+      "Epoch 0: 100%|██████████| 4160/4160 [09:06<00:00,  7.62it/s, v_num=0, train/loss_step=0.443]\n",
+      "\u001b[36m(RayTrainWorker pid=3311122)\u001b[0m \n",
+      "Validation: |          | 0/? [00:00<?, ?it/s]\u001b[A\n",
+      "\u001b[36m(RayTrainWorker pid=3311122)\u001b[0m \n",
+      "Validation:   0%|          | 0/1024 [00:00<?, ?it/s]\u001b[A\n",
+      "Validation DataLoader 0:   0%|          | 0/1024 [00:00<?, ?it/s]\u001b[A\n",
+      ".\n",
+      ".\n",
+      ".\n",
+      "Validation DataLoader 0: 100%|█████████▉| 1020/1024 [01:14<00:00, 13.65it/s]\u001b[A\n",
+      "Validation DataLoader 0: 100%|█████████▉| 1021/1024 [01:14<00:00, 13.66it/s]\u001b[A\n",
+      "Validation DataLoader 0: 100%|█████████▉| 1022/1024 [01:14<00:00, 13.67it/s]\u001b[A\n",
+      "\u001b[36m(RayTrainWorker pid=3311122)\u001b[0m \n",
+      "Validation DataLoader 0: 100%|█████████▉| 1023/1024 [01:14<00:00, 13.67it/s]\u001b[A\n",
+      "Validation DataLoader 0: 100%|██████████| 1024/1024 [01:14<00:00, 13.68it/s]\u001b[A\n",
+      "Epoch 0: 100%|██████████| 4160/4160 [10:44<00:00,  6.45it/s, v_num=0, train/loss_step=0.443, val/loss=0.543, val/f1=0.843, val/macro_acc=0.841, val/micro_acc=0.945, val/precision=0.847, val/recall=0.841, val/specificity=0.999, val/weighted_acc=0.945]\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "\u001b[36m(RayTrainWorker pid=3311122)\u001b[0m /tmp/ray/session_2025-09-29_15-57-32_695037_3287714/runtime_resources/working_dir_files/_ray_pkg_0bc7f6254ceca816/.venv/lib/python3.11/site-packages/lightning/pytorch/trainer/connectors/logger_connector/result.py:434: It is recommended to use `self.log('train/loss', ..., sync_dist=True)` when logging on epoch level in distributed setting to accumulate the metric across devices.\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Epoch 0: 100%|██████████| 4160/4160 [10:44<00:00,  6.45it/s, v_num=0, train/loss_step=0.443, val/loss=0.543, val/f1=0.843, val/macro_acc=0.841, val/micro_acc=0.945, val/precision=0.847, val/recall=0.841, val/specificity=0.999, val/weighted_acc=0.945, train/loss_epoch=0.503]\n",
+      "Epoch 0: 100%|██████████| 4160/4160 [10:45<00:00,  6.45it/s, v_num=0, train/loss_step=0.443, val/loss=0.543, val/f1=0.843, val/macro_acc=0.841, val/micro_acc=0.945, val/precision=0.847, val/recall=0.841, val/specificity=0.999, val/weighted_acc=0.945, train/loss_epoch=0.503]\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "\u001b[36m(RayTrainWorker pid=3311122)\u001b[0m Checkpoint successfully created at: Checkpoint(filesystem=local, path=/home/dtran/protoplast_results/TorchTrainer_2025-09-29_15-58-04/TorchTrainer_15473_00000_0_2025-09-29_15-58-04/checkpoint_000000)\n",
+      "\u001b[36m(RayTrainWorker pid=3311122)\u001b[0m /tmp/ray/session_2025-09-29_15-57-32_695037_3287714/runtime_resources/working_dir_files/_ray_pkg_0bc7f6254ceca816/.venv/lib/python3.11/site-packages/lightning/pytorch/trainer/connectors/logger_connector/result.py:434: It is recommended to use `self.log('train/f1', ..., sync_dist=True)` when logging on epoch level in distributed setting to accumulate the metric across devices.\n",
+      "\u001b[36m(RayTrainWorker pid=3311122)\u001b[0m /tmp/ray/session_2025-09-29_15-57-32_695037_3287714/runtime_resources/working_dir_files/_ray_pkg_0bc7f6254ceca816/.venv/lib/python3.11/site-packages/lightning/pytorch/trainer/connectors/logger_connector/result.py:434: It is recommended to use `self.log('train/macro_acc', ..., sync_dist=True)` when logging on epoch level in distributed setting to accumulate the metric across devices.\n",
+      "\u001b[36m(RayTrainWorker pid=3311122)\u001b[0m /tmp/ray/session_2025-09-29_15-57-32_695037_3287714/runtime_resources/working_dir_files/_ray_pkg_0bc7f6254ceca816/.venv/lib/python3.11/site-packages/lightning/pytorch/trainer/connectors/logger_connector/result.py:434: It is recommended to use `self.log('train/micro_acc', ..., sync_dist=True)` when logging on epoch level in distributed setting to accumulate the metric across devices.\n",
+      "\u001b[36m(RayTrainWorker pid=3311122)\u001b[0m /tmp/ray/session_2025-09-29_15-57-32_695037_3287714/runtime_resources/working_dir_files/_ray_pkg_0bc7f6254ceca816/.venv/lib/python3.11/site-packages/lightning/pytorch/trainer/connectors/logger_connector/result.py:434: It is recommended to use `self.log('train/precision', ..., sync_dist=True)` when logging on epoch level in distributed setting to accumulate the metric across devices.\n",
+      "\u001b[36m(RayTrainWorker pid=3311122)\u001b[0m /tmp/ray/session_2025-09-29_15-57-32_695037_3287714/runtime_resources/working_dir_files/_ray_pkg_0bc7f6254ceca816/.venv/lib/python3.11/site-packages/lightning/pytorch/trainer/connectors/logger_connector/result.py:434: It is recommended to use `self.log('train/recall', ..., sync_dist=True)` when logging on epoch level in distributed setting to accumulate the metric across devices.\n",
+      "\u001b[36m(RayTrainWorker pid=3311122)\u001b[0m /tmp/ray/session_2025-09-29_15-57-32_695037_3287714/runtime_resources/working_dir_files/_ray_pkg_0bc7f6254ceca816/.venv/lib/python3.11/site-packages/lightning/pytorch/trainer/connectors/logger_connector/result.py:434: It is recommended to use `self.log('train/specificity', ..., sync_dist=True)` when logging on epoch level in distributed setting to accumulate the metric across devices.\n",
+      "\u001b[36m(RayTrainWorker pid=3311122)\u001b[0m /tmp/ray/session_2025-09-29_15-57-32_695037_3287714/runtime_resources/working_dir_files/_ray_pkg_0bc7f6254ceca816/.venv/lib/python3.11/site-packages/lightning/pytorch/trainer/connectors/logger_connector/result.py:434: It is recommended to use `self.log('train/weighted_acc', ..., sync_dist=True)` when logging on epoch level in distributed setting to accumulate the metric across devices.\n",
+      "\u001b[36m(RayTrainWorker pid=3311122)\u001b[0m `Trainer.fit` stopped: `max_epochs=1` reached.\n"
+     ]
+    }
+   ],
+   "source": [
+    "%%time\n",
+    "sims_trainer = RayTrainRunner(\n",
+    "    SIMSClassifier,\n",
+    "    Dcl,\n",
+    "    [\"input_dim\", \"output_dim\"],  # maps to SIMSClassifier(input_dim, output_dim)\n",
+    "    sims_metadata_cb,\n",
+    "    ray_trainer_strategy=RayDDPStrategy(find_unused_parameters=True),\n",
+    ")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "bb1d58ff",
+   "metadata": {},
+   "source": [
+    "On a machine with **1 GPU (NVIDIA GeForce RTX 3080 - 12 GiB)**, **96 CPUs**, and **125 GiB RAM**, running `sims_trainer.train()` completed in about **14 minutes**."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 7,
+   "id": "ZHCJ",
+   "metadata": {
+    "scrolled": true
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Setting thread_per_worker to half of the available CPUs capped at 4\n",
+      "Using 1 workers with {'CPU': 4} each\n",
+      "=========Length of val_split 65 length of test_split 0 length of train_split 262\n",
+      "=========Length of after dropping remainder val_split 64 length of test_split 0 length of train_split 260\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "2025-09-29 15:58:04,345\tINFO tune.py:616 -- [output] This uses the legacy output and progress reporter, as Jupyter notebooks are not supported by the new engine, yet. For more information, please see https://github.com/ray-project/ray/issues/36949\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Data splitting time: 20.92 seconds\n",
+      "Spawning Ray worker and initiating distributed training\n",
+      "== Status ==\n",
+      "Current time: 2025-09-29 15:58:04 (running for 00:00:00.12)\n",
+      "Using FIFO scheduling algorithm.\n",
+      "Logical resource usage: 0/96 CPUs, 0/1 GPUs (0.0/1.0 accelerator_type:G)\n",
+      "Result logdir: /tmp/ray/session_2025-09-29_15-57-32_695037_3287714/artifacts/2025-09-29_15-58-04/TorchTrainer_2025-09-29_15-58-04/driver_artifacts\n",
+      "Number of trials: 1/1 (1 PENDING)\n",
+      "\n",
+      "\n",
+      "== Status ==\n",
+      "Current time: 2025-09-29 15:58:29 (running for 00:00:25.37)\n",
+      "Using FIFO scheduling algorithm.\n",
+      "Logical resource usage: 5.0/96 CPUs, 1.0/1 GPUs (0.0/1.0 accelerator_type:G)\n",
+      "Result logdir: /tmp/ray/session_2025-09-29_15-57-32_695037_3287714/artifacts/2025-09-29_15-58-04/TorchTrainer_2025-09-29_15-58-04/driver_artifacts\n",
+      "Number of trials: 1/1 (1 RUNNING)\n",
+      "\n",
+      "\n",
+      "== Status ==\n",
+      "Current time: 2025-09-29 16:10:54 (running for 00:12:50.01)\n",
+      "Using FIFO scheduling algorithm.\n",
+      "Logical resource usage: 5.0/96 CPUs, 1.0/1 GPUs (0.0/1.0 accelerator_type:G)\n",
+      "Result logdir: /tmp/ray/session_2025-09-29_15-57-32_695037_3287714/artifacts/2025-09-29_15-58-04/TorchTrainer_2025-09-29_15-58-04/driver_artifacts\n",
+      "Number of trials: 1/1 (1 RUNNING)\n",
+      "\n",
+      "\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "2025-09-29 16:10:56,469\tINFO tune.py:1009 -- Wrote the latest version of all result files and experiment state to '/home/dtran/protoplast_results/TorchTrainer_2025-09-29_15-58-04' in 0.0130s.\n",
+      "2025-09-29 16:10:56,473\tINFO tune.py:1041 -- Total run time: 772.13 seconds (772.10 seconds for the tuning loop).\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "== Status ==\n",
+      "Current time: 2025-09-29 16:10:56 (running for 00:12:52.11)\n",
+      "Using FIFO scheduling algorithm.\n",
+      "Logical resource usage: 5.0/96 CPUs, 1.0/1 GPUs (0.0/1.0 accelerator_type:G)\n",
+      "Result logdir: /tmp/ray/session_2025-09-29_15-57-32_695037_3287714/artifacts/2025-09-29_15-58-04/TorchTrainer_2025-09-29_15-58-04/driver_artifacts\n",
+      "Number of trials: 1/1 (1 TERMINATED)\n",
+      "\n",
+      "\n",
+      "CPU times: user 31.8 s, sys: 4.9 s, total: 36.7 s\n",
+      "Wall time: 13min 15s\n"
+     ]
+    }
+   ],
+   "source": [
+    "%%time\n",
+    "sims_trainer.train(\n",
+    "    file_paths,\n",
+    "    batch_size,  # 2000\n",
+    "    test_size,  # 0.0\n",
+    "    val_size,  # 0.2\n",
+    ")\n",
+    "ray.shutdown()"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "ROlb",
+   "metadata": {},
+   "source": [
+    "## 4. Autoencoder\n",
+    "- An **autoencoder** is an unsupervised neural network consisting of three main components:  \n",
+    "  - **Encoder**: compresses the input into a lower-dimensional representation.  \n",
+    "  - **Bottleneck**: stores the compressed features.  \n",
+    "  - **Decoder**: reconstructs the input from the bottleneck representation.  \n",
+    "- In this setup, separate encoders process **gene** and **protein** data. Their outputs are concatenated, passed through an additional encoder to form the bottleneck, and then decoded back to the original input.  \n",
+    "- Since **Tahoe-100M** does not include protein data, the protein input is set to `0`, and the source code was adapted to ensure compatibility with datasets lacking protein features.\n",
+    "- For testing purposes, we temporarily set mid = 128, which reduces the hidden layer size and simplifies the model architecture. For implementation details, see the [CITE-seq autoencoder source code](https://github.com/naity/citeseq_autoencoder/blob/main/autoencoder_citeseq_saturn.ipynb)."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 8,
+   "id": "1fed382e-57ce-4209-8d44-9304f686aa5d",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# group linear, batchnorm, and dropout layers. This module was from citeseq_autoencoder notebook\n",
+    "import lightning.pytorch as pl\n",
+    "import torch\n",
+    "import torch.nn.functional as F\n",
+    "from torch import nn, optim\n",
+    "\n",
+    "\n",
+    "class LinBnDrop(nn.Sequential):\n",
+    "    \"\"\"Module grouping `BatchNorm1d`, `Dropout` and `Linear` layers, adapted from fastai.\"\"\"\n",
+    "\n",
+    "    def __init__(self, n_in, n_out, bn=True, p=0.0, act=None, lin_first=True):\n",
+    "        layers = [nn.BatchNorm1d(n_out if lin_first else n_in)] if bn else []\n",
+    "        if p != 0:\n",
+    "            layers.append(nn.Dropout(p))\n",
+    "        lin = [nn.Linear(n_in, n_out, bias=not bn)]\n",
+    "        if act is not None:\n",
+    "            lin.append(act)\n",
+    "        layers = lin + layers if lin_first else layers + lin\n",
+    "        super().__init__(*layers)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "a34de981-1801-4843-bb78-094f5f69435d",
+   "metadata": {},
+   "source": [
+    "We implement an encoder that processes RNA features through a two-layer MLP (`nfeatures_rna` → `mid=128` → `hidden_rna`, with `mid=2` set for testing). The source code is from [CITE-seq autoencoder source code](https://github.com/naity/citeseq_autoencoder/blob/main/autoencoder_citeseq_saturn.ipynb)."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 9,
+   "id": "5caadfbd-c2f0-423e-9a96-f9b6dd59baab",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "class Encoder(nn.Module):\n",
+    "    \"\"\"Encoder for CITE-seq data\"\"\"\n",
+    "\n",
+    "    def __init__(\n",
+    "        self, nfeatures_rna: int, nfeatures_pro: int, hidden_rna: int, hidden_pro: int, latent_dim: int, p: float = 0\n",
+    "    ):\n",
+    "        super().__init__()\n",
+    "        self.nfeatures_rna = nfeatures_rna\n",
+    "        self.nfeatures_pro = nfeatures_pro\n",
+    "\n",
+    "        if nfeatures_rna > 0:\n",
+    "            mid = 128  # 128 is for testing the code\n",
+    "            self.encoder_rna = nn.Sequential(\n",
+    "                LinBnDrop(nfeatures_rna, mid, p=p, act=nn.LeakyReLU()),\n",
+    "                LinBnDrop(mid, hidden_rna, act=nn.LeakyReLU()),\n",
+    "            )\n",
+    "\n",
+    "        if nfeatures_pro > 0:\n",
+    "            self.encoder_protein = LinBnDrop(nfeatures_pro, hidden_pro, p=p, act=nn.LeakyReLU())\n",
+    "\n",
+    "        # make sure hidden_rna and hidden_pro are set correctly\n",
+    "        hidden_rna = 0 if nfeatures_rna == 0 else hidden_rna\n",
+    "        hidden_pro = 0 if nfeatures_pro == 0 else hidden_pro\n",
+    "\n",
+    "        hidden_dim = hidden_rna + hidden_pro\n",
+    "\n",
+    "        self.encoder = LinBnDrop(hidden_dim, latent_dim, act=nn.LeakyReLU())\n",
+    "\n",
+    "    def forward(self, x):\n",
+    "        if self.nfeatures_rna > 0 and self.nfeatures_pro > 0:\n",
+    "            x_rna = self.encoder_rna(x[:, : self.nfeatures_rna])\n",
+    "            x_pro = self.encoder_protein(x[:, self.nfeatures_rna :])\n",
+    "            x = torch.cat([x_rna, x_pro], 1)\n",
+    "        elif self.nfeatures_rna > 0 and self.nfeatures_pro == 0:\n",
+    "            x = self.encoder_rna(x)\n",
+    "        elif self.nfeatures_rna == 0 and self.nfeatures_pro > 0:\n",
+    "            x = self.encoder_protein(x)\n",
+    "        return self.encoder(x)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "503455d4-dc3e-43e8-85cc-9f60377fa8a7",
+   "metadata": {},
+   "source": [
+    "We implement a decoder that maps the latent vector to the RNA feature space by first expanding it to `hidden_rna`, passing it through a small intermediate layer (`mid_out` = `128`, used for testing), and finally projecting it to the RNA output dimension. The source code is from [CITE-seq autoencoder source code](https://github.com/naity/citeseq_autoencoder/blob/main/autoencoder_citeseq_saturn.ipynb)."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 10,
+   "id": "fc2d627b-fe57-4419-926f-14b371ad083c",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "class Decoder(nn.Module):\n",
+    "    \"\"\"Decoder for CITE-seq data\"\"\"\n",
+    "\n",
+    "    def __init__(self, nfeatures_rna: int, nfeatures_pro: int, hidden_rna: int, hidden_pro: int, latent_dim: int):\n",
+    "        super().__init__()\n",
+    "        # make sure hidden_rna and hidden_pro are set correctly\n",
+    "        hidden_rna = 0 if nfeatures_rna == 0 else hidden_rna\n",
+    "        hidden_pro = 0 if nfeatures_pro == 0 else hidden_pro\n",
+    "\n",
+    "        hidden_dim = hidden_rna + hidden_pro\n",
+    "        out_dim = nfeatures_rna + nfeatures_pro\n",
+    "        mid_out = 128  # 128 is for testing the code\n",
+    "\n",
+    "        self.decoder = nn.Sequential(\n",
+    "            LinBnDrop(latent_dim, hidden_dim, act=nn.LeakyReLU()),\n",
+    "            LinBnDrop(hidden_dim, mid_out, act=nn.LeakyReLU()),\n",
+    "            LinBnDrop(mid_out, out_dim, bn=False),\n",
+    "        )\n",
+    "\n",
+    "    def forward(self, x):\n",
+    "        return self.decoder(x)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "be00e509-8a29-4026-92a5-fa3a3213ff1f",
+   "metadata": {},
+   "source": [
+    "The encoder and decoder are assembled into an autoencoder, which is defined as a PyTorch Lightning Module to simplify the training process. The source code is from [CITE-seq autoencoder source code](https://github.com/naity/citeseq_autoencoder/blob/main/autoencoder_citeseq_saturn.ipynb)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 11,
+   "id": "78797222-d09b-4456-97aa-565cebf017ac",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "class CiteAutoencoder(pl.LightningModule):\n",
+    "    def __init__(\n",
+    "        self,\n",
+    "        nfeatures_rna: int,\n",
+    "        nfeatures_pro: int,\n",
+    "        hidden_rna: int,\n",
+    "        hidden_pro: int,\n",
+    "        latent_dim: int,\n",
+    "        p: float = 0,\n",
+    "        lr: float = 0.1,\n",
+    "    ):\n",
+    "        \"\"\"Autoencoder for citeseq data\"\"\"\n",
+    "        super().__init__()\n",
+    "\n",
+    "        # save hyperparameters\n",
+    "        self.save_hyperparameters()\n",
+    "\n",
+    "        self.encoder = Encoder(nfeatures_rna, nfeatures_pro, hidden_rna, hidden_pro, latent_dim, p)\n",
+    "        self.decoder = Decoder(nfeatures_rna, nfeatures_pro, hidden_rna, hidden_pro, latent_dim)\n",
+    "\n",
+    "        # example input array for visualizing network graph\n",
+    "        self.example_input_array = torch.zeros(256, nfeatures_rna + nfeatures_pro)\n",
+    "\n",
+    "    def forward(self, x):\n",
+    "        # extract latent embeddings\n",
+    "        z = self.encoder(x)\n",
+    "        return z\n",
+    "\n",
+    "    def configure_optimizers(self):\n",
+    "        optimizer = optim.Adam(self.parameters(), lr=self.hparams.lr)\n",
+    "        scheduler = optim.lr_scheduler.ReduceLROnPlateau(optimizer)\n",
+    "        return {\"optimizer\": optimizer, \"lr_scheduler\": scheduler, \"monitor\": \"val_loss\"}\n",
+    "\n",
+    "    def _get_reconstruction_loss(self, batch):\n",
+    "        \"\"\"Calculate MSE loss for a given batch.\"\"\"\n",
+    "        x, _ = batch\n",
+    "        z = self.encoder(x)\n",
+    "        x_hat = self.decoder(z)\n",
+    "        # MSE loss\n",
+    "        loss = F.mse_loss(x_hat, x)\n",
+    "        return loss\n",
+    "\n",
+    "    def training_step(self, batch, batch_idx):\n",
+    "        loss = self._get_reconstruction_loss(batch)\n",
+    "        self.log(\"train_loss\", loss)\n",
+    "        return loss\n",
+    "\n",
+    "    def validation_step(self, batch, batch_idx):\n",
+    "        loss = self._get_reconstruction_loss(batch)\n",
+    "        self.log(\"val_loss\", loss)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "qnkX",
+   "metadata": {},
+   "source": [
+    "### Autoencoder Metadata Callback\n",
+    "- The `ae_metadata_cb` function extends `cell_line_metadata_cb` and configures the metadata required for training the autoencoder. It sets up cell line information, defines feature counts, and specifies key model hyperparameters such as hidden dimensions, latent space size, dropout, and learning rate\n",
+    "\n",
+    "**Note (for testing):**  \n",
+    "In `ae_metadata_cb`, both the hidden RNA dimension (`hidden_rna=128`) and the latent dimension (`latent_dim=16`) are intentionally set to very small values. This configuration is used for quick testing and validation, not for full-scale training."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 12,
+   "id": "TqIu",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "def ae_metadata_cb(ad, metadata):\n",
+    "    cell_line_metadata_cb(ad, metadata)\n",
+    "    metadata[\"cell_lines\"] = np.sort(np.unique(ad.obs[\"cell_line\"].to_numpy()))\n",
+    "    metadata[\"nfeatures_rna\"] = metadata[\"num_genes\"]\n",
+    "    metadata[\"nfeatures_pro\"] = 0\n",
+    "    metadata[\"hidden_rna\"] = 128\n",
+    "    metadata[\"hidden_pro\"] = 0\n",
+    "    metadata[\"latent_dim\"] = 16\n",
+    "    metadata[\"p\"] = 0.1\n",
+    "    metadata[\"lr\"] = 1e-3"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "Vxnm",
+   "metadata": {},
+   "source": [
+    "### Training the CiteAutoencoder model\n",
+    "- The dataset (`Dcl`) is provided along with key model parameters such as RNA/protein feature counts, hidden layer sizes, latent dimension, dropout p, and learning rate lr, all supplied through the `ae_metadata_cb` callback."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 13,
+   "id": "DnEU",
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "2025-09-29 16:12:13,554\tINFO worker.py:1951 -- Started a local Ray instance.\n",
+      "2025-09-29 16:12:14,575\tINFO packaging.py:588 -- Creating a file package for local module '/mnt/hdd1/dung/protoplast-ml-example'.\n",
+      "2025-09-29 16:12:14,706\tWARNING packaging.py:430 -- File /mnt/hdd1/dung/protoplast-ml-example/.git/modules/submodules/SIMS/objects/pack/pack-682433dc4cf8becc2b44606f464dde9068565261.pack is very large (34.70MiB). Consider adding this file to the 'excludes' list to skip uploading it: `ray.init(..., runtime_env={'excludes': ['/mnt/hdd1/dung/protoplast-ml-example/.git/modules/submodules/SIMS/objects/pack/pack-682433dc4cf8becc2b44606f464dde9068565261.pack']})`\n",
+      "2025-09-29 16:12:14,931\tINFO packaging.py:380 -- Pushing file package 'gcs://_ray_pkg_44eaeac1790d7085.zip' (70.05MiB) to Ray cluster...\n",
+      "2025-09-29 16:12:15,371\tINFO packaging.py:393 -- Successfully pushed file package 'gcs://_ray_pkg_44eaeac1790d7085.zip'.\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "CPU times: user 586 ms, sys: 694 ms, total: 1.28 s\n",
+      "Wall time: 10.6 s\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "\u001b[33m(raylet)\u001b[0m \u001b[1m\u001b[33mwarning\u001b[39m\u001b[0m\u001b[1m:\u001b[0m \u001b[1m`VIRTUAL_ENV=/mnt/hdd1/dung/protoplast-ml-example/.venv` does not match the project environment path `.venv` and will be ignored; use `--active` to target the active environment instead\u001b[0m\n",
+      "\u001b[33m(raylet)\u001b[0m Using CPython \u001b[36m3.11.13\u001b[39m\n",
+      "\u001b[33m(raylet)\u001b[0m Creating virtual environment at: \u001b[36m.venv\u001b[39m\n",
+      "\u001b[33m(raylet)\u001b[0m \u001b[2mInstalled \u001b[1m296 packages\u001b[0m \u001b[2min 323ms\u001b[0m\u001b[0m\n",
+      "\u001b[33m(raylet)\u001b[0m \u001b[1m\u001b[33mwarning\u001b[39m\u001b[0m\u001b[1m:\u001b[0m \u001b[1m`VIRTUAL_ENV=/mnt/hdd1/dung/protoplast-ml-example/.venv` does not match the project environment path `.venv` and will be ignored; use `--active` to target the active environment instead\u001b[0m\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "\u001b[36m(TrainTrainable pid=3330047)\u001b[0m ✓ Applied AnnDataFileManager patch, AnnData cannot be imported after the patch!\n",
+      "\u001b[36m(TrainTrainable pid=3330047)\u001b[0m ✓ Applied AnnDataFileManager patch, AnnData cannot be imported after the patch!\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "\u001b[33m(raylet)\u001b[0m \u001b[1m\u001b[33mwarning\u001b[39m\u001b[0m\u001b[1m:\u001b[0m \u001b[1m`VIRTUAL_ENV=/mnt/hdd1/dung/protoplast-ml-example/.venv` does not match the project environment path `.venv` and will be ignored; use `--active` to target the active environment instead\u001b[0m\n",
+      "\u001b[36m(RayTrainWorker pid=3330754)\u001b[0m Setting up process group for: env:// [rank=0, world_size=1]\n",
+      "\u001b[36m(TorchTrainer pid=3330047)\u001b[0m Started distributed worker processes: \n",
+      "\u001b[36m(TorchTrainer pid=3330047)\u001b[0m - (node_id=661dfa72632cd7bdac4b2f4696086471aadc4dae065ed3a2b92450de, ip=192.168.1.226, pid=3330754) world_rank=0, local_rank=0, node_rank=0\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "\u001b[36m(RayTrainWorker pid=3330754)\u001b[0m ✓ Applied AnnDataFileManager patch, AnnData cannot be imported after the patch!\n",
+      "\u001b[36m(RayTrainWorker pid=3330754)\u001b[0m ✓ Applied AnnDataFileManager patch, AnnData cannot be imported after the patch!\n",
+      "\u001b[36m(RayTrainWorker pid=3330754)\u001b[0m =========Starting the training on 0 with num threads: 4=========\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "\u001b[36m(RayTrainWorker pid=3330754)\u001b[0m 💡 Tip: For seamless cloud uploads and versioning, try installing [litmodels](https://pypi.org/project/litmodels/) to enable LitModelCheckpoint, which syncs automatically with the Lightning model registry.\n",
+      "\u001b[36m(RayTrainWorker pid=3330754)\u001b[0m GPU available: True (cuda), used: True\n",
+      "\u001b[36m(RayTrainWorker pid=3330754)\u001b[0m TPU available: False, using: 0 TPU cores\n",
+      "\u001b[36m(RayTrainWorker pid=3330754)\u001b[0m HPU available: False, using: 0 HPUs\n",
+      "\u001b[36m(RayTrainWorker pid=3330754)\u001b[0m /tmp/ray/session_2025-09-29_16-12-08_641985_3287714/runtime_resources/working_dir_files/_ray_pkg_44eaeac1790d7085/.venv/lib/python3.11/site-packages/lightning/fabric/plugins/environments/slurm.py:204: The `srun` command is available on your system but is not used. HINT: If your intention is to run Lightning on SLURM, prepend your python command with `srun` like so: srun python3 /mnt/hdd1/dung/protoplast-ml-example/.venv/lib/pyth ...\n",
+      "\u001b[36m(RayTrainWorker pid=3330754)\u001b[0m You are using a CUDA device ('NVIDIA GeForce RTX 3080') that has Tensor Cores. To properly utilize them, you should set `torch.set_float32_matmul_precision('medium' | 'high')` which will trade-off precision for performance. For more details, read https://pytorch.org/docs/stable/generated/torch.set_float32_matmul_precision.html#torch.set_float32_matmul_precision\n",
+      "\u001b[36m(RayTrainWorker pid=3330754)\u001b[0m LOCAL_RANK: 0 - CUDA_VISIBLE_DEVICES: [0]\n",
+      "\u001b[36m(RayTrainWorker pid=3330754)\u001b[0m \n",
+      "\u001b[36m(RayTrainWorker pid=3330754)\u001b[0m   | Name    | Type    | Params | Mode  | In sizes     | Out sizes\n",
+      "\u001b[36m(RayTrainWorker pid=3330754)\u001b[0m -----------------------------------------------------------------------\n",
+      "\u001b[36m(RayTrainWorker pid=3330754)\u001b[0m 0 | encoder | Encoder | 8.0 M  | train | [256, 62710] | [256, 16]\n",
+      "\u001b[36m(RayTrainWorker pid=3330754)\u001b[0m 1 | decoder | Decoder | 8.1 M  | train | ?            | ?        \n",
+      "\u001b[36m(RayTrainWorker pid=3330754)\u001b[0m -----------------------------------------------------------------------\n",
+      "\u001b[36m(RayTrainWorker pid=3330754)\u001b[0m 16.2 M    Trainable params\n",
+      "\u001b[36m(RayTrainWorker pid=3330754)\u001b[0m 0         Non-trainable params\n",
+      "\u001b[36m(RayTrainWorker pid=3330754)\u001b[0m 16.2 M    Total params\n",
+      "\u001b[36m(RayTrainWorker pid=3330754)\u001b[0m 64.618    Total estimated model params size (MB)\n",
+      "\u001b[36m(RayTrainWorker pid=3330754)\u001b[0m 27        Modules in train mode\n",
+      "\u001b[36m(RayTrainWorker pid=3330754)\u001b[0m 0         Modules in eval mode\n",
+      "\u001b[36m(RayTrainWorker pid=3330754)\u001b[0m /tmp/ray/session_2025-09-29_16-12-08_641985_3287714/runtime_resources/working_dir_files/_ray_pkg_44eaeac1790d7085/.venv/lib/python3.11/site-packages/torch/distributed/distributed_c10d.py:4807: UserWarning: No device id is provided via `init_process_group` or `barrier `. Using the current device set by the user. \n",
+      "\u001b[36m(RayTrainWorker pid=3330754)\u001b[0m   warnings.warn(  # warn only once\n",
+      "\u001b[36m(RayTrainWorker pid=3330754)\u001b[0m /tmp/ray/session_2025-09-29_16-12-08_641985_3287714/runtime_resources/working_dir_files/_ray_pkg_44eaeac1790d7085/.venv/lib/python3.11/site-packages/lightning/pytorch/utilities/data.py:123: Your `IterableDataset` has `__len__` defined. In combination with multi-process data loading (when num_workers > 1), `__len__` could be inaccurate if each worker is not configured independently to avoid having duplicate data.\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Sanity Checking: |          | 0/? [00:00<?, ?it/s]\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "\u001b[36m(RayTrainWorker pid=3330754)\u001b[0m /tmp/ray/session_2025-09-29_16-12-08_641985_3287714/runtime_resources/working_dir_files/_ray_pkg_44eaeac1790d7085/submodules/protoplast/src/protoplast/scrna/anndata/torch_dataloader.py:130: UserWarning: Sparse CSR tensor support is in beta state. If you miss a functionality in the sparse tensor support, please submit a feature request to https://github.com/pytorch/pytorch/issues. (Triggered internally at /pytorch/aten/src/ATen/SparseCsrTensorImpl.cpp:53.)\n",
+      "\u001b[36m(RayTrainWorker pid=3330754)\u001b[0m   return torch.sparse_csr_tensor(\n",
+      "\u001b[36m(RayTrainWorker pid=3330754)\u001b[0m /tmp/ray/session_2025-09-29_16-12-08_641985_3287714/runtime_resources/working_dir_files/_ray_pkg_44eaeac1790d7085/.venv/lib/python3.11/site-packages/torch/multiprocessing/reductions.py:473: UserWarning: Sparse CSR tensor support is in beta state. If you miss a functionality in the sparse tensor support, please submit a feature request to https://github.com/pytorch/pytorch/issues. (Triggered internally at /pytorch/aten/src/ATen/SparseCsrTensorImpl.cpp:53.)\n",
+      "\u001b[36m(RayTrainWorker pid=3330754)\u001b[0m   return torch.sparse_compressed_tensor(\n",
+      "\u001b[36m(RayTrainWorker pid=3330754)\u001b[0m /tmp/ray/session_2025-09-29_16-12-08_641985_3287714/runtime_resources/working_dir_files/_ray_pkg_44eaeac1790d7085/submodules/protoplast/src/protoplast/scrna/anndata/torch_dataloader.py:130: UserWarning: Sparse CSR tensor support is in beta state. If you miss a functionality in the sparse tensor support, please submit a feature request to https://github.com/pytorch/pytorch/issues. (Triggered internally at /pytorch/aten/src/ATen/SparseCsrTensorImpl.cpp:53.)\n",
+      "\u001b[36m(RayTrainWorker pid=3330754)\u001b[0m   return torch.sparse_csr_tensor(\n",
+      "\u001b[36m(RayTrainWorker pid=3330754)\u001b[0m /tmp/ray/session_2025-09-29_16-12-08_641985_3287714/runtime_resources/working_dir_files/_ray_pkg_44eaeac1790d7085/submodules/protoplast/src/protoplast/scrna/anndata/torch_dataloader.py:130: UserWarning: Sparse CSR tensor support is in beta state. If you miss a functionality in the sparse tensor support, please submit a feature request to https://github.com/pytorch/pytorch/issues. (Triggered internally at /pytorch/aten/src/ATen/SparseCsrTensorImpl.cpp:53.)\n",
+      "\u001b[36m(RayTrainWorker pid=3330754)\u001b[0m   return torch.sparse_csr_tensor(\n",
+      "\u001b[36m(RayTrainWorker pid=3330754)\u001b[0m /tmp/ray/session_2025-09-29_16-12-08_641985_3287714/runtime_resources/working_dir_files/_ray_pkg_44eaeac1790d7085/submodules/protoplast/src/protoplast/scrna/anndata/torch_dataloader.py:130: UserWarning: Sparse CSR tensor support is in beta state. If you miss a functionality in the sparse tensor support, please submit a feature request to https://github.com/pytorch/pytorch/issues. (Triggered internally at /pytorch/aten/src/ATen/SparseCsrTensorImpl.cpp:53.)\n",
+      "\u001b[36m(RayTrainWorker pid=3330754)\u001b[0m   return torch.sparse_csr_tensor(\n",
+      "\u001b[36m(RayTrainWorker pid=3330754)\u001b[0m /tmp/ray/session_2025-09-29_16-12-08_641985_3287714/runtime_resources/working_dir_files/_ray_pkg_44eaeac1790d7085/.venv/lib/python3.11/site-packages/lightning/pytorch/trainer/connectors/logger_connector/result.py:434: It is recommended to use `self.log('val_loss', ..., sync_dist=True)` when logging on epoch level in distributed setting to accumulate the metric across devices.\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "                                                                           \n",
+      "Epoch 0:   0%|          | 0/4160 [00:00<?, ?it/s] \n",
+      "Epoch 0:   0%|          | 2/4160 [00:22<13:16:53,  0.09it/s, v_num=0]\n",
+      "Epoch 0:   0%|          | 3/4160 [00:23<8:51:51,  0.13it/s, v_num=0] \n",
+      ".\n",
+      ".\n",
+      ".\n",
+      "Epoch 0: 100%|█████████▉| 4153/4160 [05:31<00:00, 12.52it/s, v_num=0]\n",
+      "Epoch 0: 100%|█████████▉| 4156/4160 [05:31<00:00, 12.52it/s, v_num=0]\n",
+      "Epoch 0: 100%|█████████▉| 4159/4160 [05:31<00:00, 12.53it/s, v_num=0]\n",
+      "Epoch 0: 100%|██████████| 4160/4160 [05:31<00:00, 12.53it/s, v_num=0]\n",
+      "\u001b[36m(RayTrainWorker pid=3330754)\u001b[0m \n",
+      "Validation: |          | 0/? [00:00<?, ?it/s]\u001b[A\n",
+      "\u001b[36m(RayTrainWorker pid=3330754)\u001b[0m \n",
+      "Validation:   0%|          | 0/1024 [00:00<?, ?it/s]\u001b[A\n",
+      "Validation DataLoader 0:   0%|          | 0/1024 [00:00<?, ?it/s]\u001b[A\n",
+      "Validation DataLoader 0:   0%|          | 1/1024 [00:00<00:12, 79.73it/s]\u001b[A\n",
+      ".\n",
+      ".\n",
+      ".\n",
+      "Validation DataLoader 0: 100%|█████████▉| 1019/1024 [01:03<00:00, 16.02it/s]\u001b[A\n",
+      "Validation DataLoader 0: 100%|█████████▉| 1020/1024 [01:03<00:00, 16.03it/s]\u001b[A\n",
+      "Validation DataLoader 0: 100%|█████████▉| 1021/1024 [01:03<00:00, 16.03it/s]\u001b[A\n",
+      "\u001b[36m(RayTrainWorker pid=3330754)\u001b[0m \n",
+      "Validation DataLoader 0: 100%|█████████▉| 1022/1024 [01:03<00:00, 16.04it/s]\u001b[A\n",
+      "Validation DataLoader 0: 100%|█████████▉| 1023/1024 [01:03<00:00, 16.05it/s]\u001b[A\n",
+      "Validation DataLoader 0: 100%|██████████| 1024/1024 [01:03<00:00, 16.06it/s]\u001b[A\n",
+      "Epoch 0: 100%|██████████| 4160/4160 [07:07<00:00,  9.74it/s, v_num=0]       \u001b[A\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "\u001b[36m(RayTrainWorker pid=3330754)\u001b[0m Checkpoint successfully created at: Checkpoint(filesystem=local, path=/home/dtran/protoplast_results/TorchTrainer_2025-09-29_16-12-46/TorchTrainer_23398_00000_0_2025-09-29_16-12-46/checkpoint_000000)\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Epoch 0: 100%|██████████| 4160/4160 [07:07<00:00,  9.72it/s, v_num=0]\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "\u001b[36m(RayTrainWorker pid=3330754)\u001b[0m `Trainer.fit` stopped: `max_epochs=1` reached.\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Epoch 0: 100%|██████████| 4160/4160 [07:08<00:00,  9.71it/s, v_num=0]\n"
+     ]
+    }
+   ],
+   "source": [
+    "%%time\n",
+    "autoencoder_trainer = RayTrainRunner(\n",
+    "    CiteAutoencoder,\n",
+    "    Dcl,\n",
+    "    [\"nfeatures_rna\", \"nfeatures_pro\", \"hidden_rna\", \"hidden_pro\", \"latent_dim\", \"p\", \"lr\"],\n",
+    "    metadata_cb=ae_metadata_cb,\n",
+    ")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "dd758cb8",
+   "metadata": {},
+   "source": [
+    "On a machine with **1 GPU (NVIDIA GeForce RTX 3080 - 12GiB) + 96 CPUs + 125GiB RAM**, `autoencoder_trainer()` finished in **9 minutes**"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 14,
+   "id": "ulZA",
+   "metadata": {
+    "scrolled": true
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Setting thread_per_worker to half of the available CPUs capped at 4\n",
+      "Using 1 workers with {'CPU': 4} each\n",
+      "=========Length of val_split 65 length of test_split 0 length of train_split 262\n",
+      "=========Length of after dropping remainder val_split 64 length of test_split 0 length of train_split 260\n",
+      "Data splitting time: 27.48 seconds\n",
+      "Spawning Ray worker and initiating distributed training\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "2025-09-29 16:12:46,739\tINFO tune.py:616 -- [output] This uses the legacy output and progress reporter, as Jupyter notebooks are not supported by the new engine, yet. For more information, please see https://github.com/ray-project/ray/issues/36949\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "== Status ==\n",
+      "Current time: 2025-09-29 16:12:46 (running for 00:00:00.12)\n",
+      "Using FIFO scheduling algorithm.\n",
+      "Logical resource usage: 0/96 CPUs, 0/1 GPUs (0.0/1.0 accelerator_type:G)\n",
+      "Result logdir: /tmp/ray/session_2025-09-29_16-12-08_641985_3287714/artifacts/2025-09-29_16-12-46/TorchTrainer_2025-09-29_16-12-46/driver_artifacts\n",
+      "Number of trials: 1/1 (1 PENDING)\n",
+      "\n",
+      "\n",
+      "== Status ==\n",
+      "Current time: 2025-09-29 16:13:12 (running for 00:00:25.26)\n",
+      "Using FIFO scheduling algorithm.\n",
+      "Logical resource usage: 5.0/96 CPUs, 1.0/1 GPUs (0.0/1.0 accelerator_type:G)\n",
+      "Result logdir: /tmp/ray/session_2025-09-29_16-12-08_641985_3287714/artifacts/2025-09-29_16-12-46/TorchTrainer_2025-09-29_16-12-46/driver_artifacts\n",
+      "Number of trials: 1/1 (1 RUNNING)\n",
+      "\n",
+      "\n",
+      "== Status ==\n",
+      "Current time: 2025-09-29 16:21:00 (running for 00:08:13.75)\n",
+      "Using FIFO scheduling algorithm.\n",
+      "Logical resource usage: 5.0/96 CPUs, 1.0/1 GPUs (0.0/1.0 accelerator_type:G)\n",
+      "Result logdir: /tmp/ray/session_2025-09-29_16-12-08_641985_3287714/artifacts/2025-09-29_16-12-46/TorchTrainer_2025-09-29_16-12-46/driver_artifacts\n",
+      "Number of trials: 1/1 (1 RUNNING)\n",
+      "\n",
+      "\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "2025-09-29 16:21:01,711\tINFO tune.py:1009 -- Wrote the latest version of all result files and experiment state to '/home/dtran/protoplast_results/TorchTrainer_2025-09-29_16-12-46' in 0.0064s.\n",
+      "2025-09-29 16:21:01,808\tINFO tune.py:1041 -- Total run time: 495.07 seconds (494.95 seconds for the tuning loop).\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "== Status ==\n",
+      "Current time: 2025-09-29 16:21:01 (running for 00:08:14.97)\n",
+      "Using FIFO scheduling algorithm.\n",
+      "Logical resource usage: 5.0/96 CPUs, 1.0/1 GPUs (0.0/1.0 accelerator_type:G)\n",
+      "Result logdir: /tmp/ray/session_2025-09-29_16-12-08_641985_3287714/artifacts/2025-09-29_16-12-46/TorchTrainer_2025-09-29_16-12-46/driver_artifacts\n",
+      "Number of trials: 1/1 (1 TERMINATED)\n",
+      "\n",
+      "\n",
+      "CPU times: user 33.5 s, sys: 4.13 s, total: 37.6 s\n",
+      "Wall time: 8min 45s\n"
+     ]
+    }
+   ],
+   "source": [
+    "%%time\n",
+    "autoencoder_trainer.train(\n",
+    "    file_paths,\n",
+    "    batch_size,  # 2000\n",
+    "    test_size,  # 0.0\n",
+    "    val_size,  # 0.2\n",
+    ")\n",
+    "ray.shutdown()"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "b3b3ce28-2f5f-43f1-ba00-465612f9925f",
+   "metadata": {},
+   "source": [
+    "## 5. DistributedClassifierTrainingPlan\n",
+    "- **ClassifierTrainingPlan** (from `scvi-tools`) is not a model itself, but a training plan.  \n",
+    "  Its purpose is to coordinate the entire training workflow of an scvi-tools classifier, including optimization, scheduling, and evaluation.  \n",
+    "- For details, see the [source code](https://github.com/scverse/scvi-tools/blob/main/src/scvi/train/_trainingplans.py#L1479)."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "Pvdt",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# install scvi:\n",
+    "# uv add scvi-tools in terminal"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "3314d4b8-d322-4b92-97b8-8daa97889182",
+   "metadata": {},
+   "source": [
+    "### Classifier Training metadata callback\n",
+    "Calls `cell_line_metadata_cb` to extract `num_genes` and `num_classes` from the input AnnData object."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 15,
+   "id": "9555c00c-483e-46fd-8188-4318392a8eaf",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "def clf_metadata_cb(ad, metadata):\n",
+    "    # Populate num_genes / num_classes from the AnnData file\n",
+    "    cell_line_metadata_cb(ad, metadata)\n",
+    "\n",
+    "    # Create the classifier instance and attach it to metadata\n",
+    "    metadata[\"classifier\"] = Classifier(\n",
+    "        n_input=metadata[\"num_genes\"],\n",
+    "        n_labels=metadata[\"num_classes\"],\n",
+    "        logits=True,  # ClassifierTrainingPlan requirement that the module returns logits\n",
+    "    )\n",
+    "    metadata[\"lr\"] = 1e-3\n",
+    "    metadata[\"weight_decay\"] = 1e-6\n",
+    "    metadata[\"eps\"] = 0.01\n",
+    "    metadata[\"optimizer\"] = \"Adam\""
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "c2242850-ae97-4df4-9f84-761faee01690",
+   "metadata": {},
+   "source": [
+    "The `DistributedClassifierTrainingPlan` subclass extends `ClassifierTrainingPlan` by explicitly defining its own `training_step` and `validation_step`:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 16,
+   "id": "d597c453-0ec2-409a-b7dd-198b891fdd33",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "class DistributedClassifierTrainingPlan(ClassifierTrainingPlan):\n",
+    "    def training_step(self, batch, batch_idx):\n",
+    "        \"\"\"Training step for classifier training.\"\"\"\n",
+    "        x, y = batch\n",
+    "        soft_prediction = self.forward(x)\n",
+    "        loss = self.loss_fn(soft_prediction, y.view(-1).long())\n",
+    "        self.log(\"train_loss\", loss, on_epoch=True, prog_bar=True)\n",
+    "        return loss\n",
+    "\n",
+    "    def validation_step(self, batch, batch_idx):\n",
+    "        \"\"\"Validation step for classifier training.\"\"\"\n",
+    "        x, y = batch\n",
+    "        soft_prediction = self.forward(x)\n",
+    "        loss = self.loss_fn(soft_prediction, y.view(-1).long())\n",
+    "        self.log(\"validation_loss\", loss)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "c4fc5d5b-1707-493d-a388-a1a3380c1853",
+   "metadata": {},
+   "source": [
+    "### Executing ClassifierTrainingPlan"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 17,
+   "id": "507c8f51-7e90-45b5-b455-0ba5ddbf033f",
+   "metadata": {
+    "scrolled": true
+   },
+   "outputs": [
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "2025-09-29 16:22:02,568\tINFO worker.py:1951 -- Started a local Ray instance.\n",
+      "2025-09-29 16:22:03,828\tINFO packaging.py:588 -- Creating a file package for local module '/mnt/hdd1/dung/protoplast-ml-example'.\n",
+      "2025-09-29 16:22:03,967\tWARNING packaging.py:430 -- File /mnt/hdd1/dung/protoplast-ml-example/.git/modules/submodules/SIMS/objects/pack/pack-682433dc4cf8becc2b44606f464dde9068565261.pack is very large (34.70MiB). Consider adding this file to the 'excludes' list to skip uploading it: `ray.init(..., runtime_env={'excludes': ['/mnt/hdd1/dung/protoplast-ml-example/.git/modules/submodules/SIMS/objects/pack/pack-682433dc4cf8becc2b44606f464dde9068565261.pack']})`\n",
+      "2025-09-29 16:22:04,333\tINFO packaging.py:380 -- Pushing file package 'gcs://_ray_pkg_1da4f615a458d958.zip' (70.38MiB) to Ray cluster...\n",
+      "2025-09-29 16:22:05,419\tINFO packaging.py:393 -- Successfully pushed file package 'gcs://_ray_pkg_1da4f615a458d958.zip'.\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "CPU times: user 800 ms, sys: 831 ms, total: 1.63 s\n",
+      "Wall time: 12.9 s\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "\u001b[33m(raylet)\u001b[0m \u001b[1m\u001b[33mwarning\u001b[39m\u001b[0m\u001b[1m:\u001b[0m \u001b[1m`VIRTUAL_ENV=/mnt/hdd1/dung/protoplast-ml-example/.venv` does not match the project environment path `.venv` and will be ignored; use `--active` to target the active environment instead\u001b[0m\n",
+      "\u001b[33m(raylet)\u001b[0m Using CPython \u001b[36m3.11.13\u001b[39m\n",
+      "\u001b[33m(raylet)\u001b[0m Creating virtual environment at: \u001b[36m.venv\u001b[39m\n",
+      "\u001b[33m(raylet)\u001b[0m \u001b[2mInstalled \u001b[1m296 packages\u001b[0m \u001b[2min 347ms\u001b[0m\u001b[0m\n",
+      "\u001b[33m(raylet)\u001b[0m \u001b[1m\u001b[33mwarning\u001b[39m\u001b[0m\u001b[1m:\u001b[0m \u001b[1m`VIRTUAL_ENV=/mnt/hdd1/dung/protoplast-ml-example/.venv` does not match the project environment path `.venv` and will be ignored; use `--active` to target the active environment instead\u001b[0m\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "\u001b[36m(TrainTrainable pid=3351177)\u001b[0m ✓ Applied AnnDataFileManager patch, AnnData cannot be imported after the patch!\n",
+      "\u001b[36m(TrainTrainable pid=3351177)\u001b[0m ✓ Applied AnnDataFileManager patch, AnnData cannot be imported after the patch!\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "\u001b[33m(raylet)\u001b[0m \u001b[1m\u001b[33mwarning\u001b[39m\u001b[0m\u001b[1m:\u001b[0m \u001b[1m`VIRTUAL_ENV=/mnt/hdd1/dung/protoplast-ml-example/.venv` does not match the project environment path `.venv` and will be ignored; use `--active` to target the active environment instead\u001b[0m\n",
+      "\u001b[36m(RayTrainWorker pid=3352013)\u001b[0m Setting up process group for: env:// [rank=0, world_size=1]\n",
+      "\u001b[36m(TorchTrainer pid=3351177)\u001b[0m Started distributed worker processes: \n",
+      "\u001b[36m(TorchTrainer pid=3351177)\u001b[0m - (node_id=5f290d146a3444f6b76f01c2fd8cbb4ef9675d111d416f43402f2952, ip=192.168.1.226, pid=3352013) world_rank=0, local_rank=0, node_rank=0\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "\u001b[36m(RayTrainWorker pid=3352013)\u001b[0m ✓ Applied AnnDataFileManager patch, AnnData cannot be imported after the patch!\n",
+      "\u001b[36m(RayTrainWorker pid=3352013)\u001b[0m ✓ Applied AnnDataFileManager patch, AnnData cannot be imported after the patch!\n",
+      "\u001b[36m(RayTrainWorker pid=3352013)\u001b[0m =========Starting the training on 0 with num threads: 4=========\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "\u001b[36m(RayTrainWorker pid=3352013)\u001b[0m 💡 Tip: For seamless cloud uploads and versioning, try installing [litmodels](https://pypi.org/project/litmodels/) to enable LitModelCheckpoint, which syncs automatically with the Lightning model registry.\n",
+      "\u001b[36m(RayTrainWorker pid=3352013)\u001b[0m GPU available: True (cuda), used: True\n",
+      "\u001b[36m(RayTrainWorker pid=3352013)\u001b[0m TPU available: False, using: 0 TPU cores\n",
+      "\u001b[36m(RayTrainWorker pid=3352013)\u001b[0m HPU available: False, using: 0 HPUs\n",
+      "\u001b[36m(RayTrainWorker pid=3352013)\u001b[0m /tmp/ray/session_2025-09-29_16-21-57_025895_3287714/runtime_resources/working_dir_files/_ray_pkg_1da4f615a458d958/.venv/lib/python3.11/site-packages/lightning/fabric/plugins/environments/slurm.py:204: The `srun` command is available on your system but is not used. HINT: If your intention is to run Lightning on SLURM, prepend your python command with `srun` like so: srun python3 /mnt/hdd1/dung/protoplast-ml-example/.venv/lib/pyth ...\n",
+      "\u001b[36m(RayTrainWorker pid=3352013)\u001b[0m You are using a CUDA device ('NVIDIA GeForce RTX 3080') that has Tensor Cores. To properly utilize them, you should set `torch.set_float32_matmul_precision('medium' | 'high')` which will trade-off precision for performance. For more details, read https://pytorch.org/docs/stable/generated/torch.set_float32_matmul_precision.html#torch.set_float32_matmul_precision\n",
+      "\u001b[36m(RayTrainWorker pid=3352013)\u001b[0m LOCAL_RANK: 0 - CUDA_VISIBLE_DEVICES: [0]\n",
+      "\u001b[36m(RayTrainWorker pid=3352013)\u001b[0m \n",
+      "\u001b[36m(RayTrainWorker pid=3352013)\u001b[0m   | Name    | Type             | Params | Mode \n",
+      "\u001b[36m(RayTrainWorker pid=3352013)\u001b[0m -----------------------------------------------------\n",
+      "\u001b[36m(RayTrainWorker pid=3352013)\u001b[0m 0 | module  | Classifier       | 8.0 M  | train\n",
+      "\u001b[36m(RayTrainWorker pid=3352013)\u001b[0m 1 | loss_fn | CrossEntropyLoss | 0      | train\n",
+      "\u001b[36m(RayTrainWorker pid=3352013)\u001b[0m -----------------------------------------------------\n",
+      "\u001b[36m(RayTrainWorker pid=3352013)\u001b[0m 8.0 M     Trainable params\n",
+      "\u001b[36m(RayTrainWorker pid=3352013)\u001b[0m 0         Non-trainable params\n",
+      "\u001b[36m(RayTrainWorker pid=3352013)\u001b[0m 8.0 M     Total params\n",
+      "\u001b[36m(RayTrainWorker pid=3352013)\u001b[0m 32.135    Total estimated model params size (MB)\n",
+      "\u001b[36m(RayTrainWorker pid=3352013)\u001b[0m 11        Modules in train mode\n",
+      "\u001b[36m(RayTrainWorker pid=3352013)\u001b[0m 0         Modules in eval mode\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Sanity Checking: |          | 0/? [00:00<?, ?it/s]\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "\u001b[36m(RayTrainWorker pid=3352013)\u001b[0m /tmp/ray/session_2025-09-29_16-21-57_025895_3287714/runtime_resources/working_dir_files/_ray_pkg_1da4f615a458d958/.venv/lib/python3.11/site-packages/torch/distributed/distributed_c10d.py:4807: UserWarning: No device id is provided via `init_process_group` or `barrier `. Using the current device set by the user. \n",
+      "\u001b[36m(RayTrainWorker pid=3352013)\u001b[0m   warnings.warn(  # warn only once\n",
+      "\u001b[36m(RayTrainWorker pid=3352013)\u001b[0m /tmp/ray/session_2025-09-29_16-21-57_025895_3287714/runtime_resources/working_dir_files/_ray_pkg_1da4f615a458d958/.venv/lib/python3.11/site-packages/lightning/pytorch/utilities/data.py:123: Your `IterableDataset` has `__len__` defined. In combination with multi-process data loading (when num_workers > 1), `__len__` could be inaccurate if each worker is not configured independently to avoid having duplicate data.\n",
+      "\u001b[36m(RayTrainWorker pid=3352013)\u001b[0m /tmp/ray/session_2025-09-29_16-21-57_025895_3287714/runtime_resources/working_dir_files/_ray_pkg_1da4f615a458d958/submodules/protoplast/src/protoplast/scrna/anndata/torch_dataloader.py:130: UserWarning: Sparse CSR tensor support is in beta state. If you miss a functionality in the sparse tensor support, please submit a feature request to https://github.com/pytorch/pytorch/issues. (Triggered internally at /pytorch/aten/src/ATen/SparseCsrTensorImpl.cpp:53.)\n",
+      "\u001b[36m(RayTrainWorker pid=3352013)\u001b[0m   return torch.sparse_csr_tensor(\n",
+      "\u001b[36m(RayTrainWorker pid=3352013)\u001b[0m /tmp/ray/session_2025-09-29_16-21-57_025895_3287714/runtime_resources/working_dir_files/_ray_pkg_1da4f615a458d958/.venv/lib/python3.11/site-packages/torch/multiprocessing/reductions.py:473: UserWarning: Sparse CSR tensor support is in beta state. If you miss a functionality in the sparse tensor support, please submit a feature request to https://github.com/pytorch/pytorch/issues. (Triggered internally at /pytorch/aten/src/ATen/SparseCsrTensorImpl.cpp:53.)\n",
+      "\u001b[36m(RayTrainWorker pid=3352013)\u001b[0m   return torch.sparse_compressed_tensor(\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Sanity Checking DataLoader 0:   0%|          | 0/2 [00:00<?, ?it/s]\n",
+      "Sanity Checking DataLoader 0:  50%|█████     | 1/2 [00:00<00:00,  5.04it/s]\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "\u001b[36m(RayTrainWorker pid=3352013)\u001b[0m /tmp/ray/session_2025-09-29_16-21-57_025895_3287714/runtime_resources/working_dir_files/_ray_pkg_1da4f615a458d958/submodules/protoplast/src/protoplast/scrna/anndata/torch_dataloader.py:130: UserWarning: Sparse CSR tensor support is in beta state. If you miss a functionality in the sparse tensor support, please submit a feature request to https://github.com/pytorch/pytorch/issues. (Triggered internally at /pytorch/aten/src/ATen/SparseCsrTensorImpl.cpp:53.)\n",
+      "\u001b[36m(RayTrainWorker pid=3352013)\u001b[0m   return torch.sparse_csr_tensor(\n",
+      "\u001b[36m(RayTrainWorker pid=3352013)\u001b[0m /tmp/ray/session_2025-09-29_16-21-57_025895_3287714/runtime_resources/working_dir_files/_ray_pkg_1da4f615a458d958/submodules/protoplast/src/protoplast/scrna/anndata/torch_dataloader.py:130: UserWarning: Sparse CSR tensor support is in beta state. If you miss a functionality in the sparse tensor support, please submit a feature request to https://github.com/pytorch/pytorch/issues. (Triggered internally at /pytorch/aten/src/ATen/SparseCsrTensorImpl.cpp:53.)\n",
+      "\u001b[36m(RayTrainWorker pid=3352013)\u001b[0m   return torch.sparse_csr_tensor(\n",
+      "\u001b[36m(RayTrainWorker pid=3352013)\u001b[0m /tmp/ray/session_2025-09-29_16-21-57_025895_3287714/runtime_resources/working_dir_files/_ray_pkg_1da4f615a458d958/submodules/protoplast/src/protoplast/scrna/anndata/torch_dataloader.py:130: UserWarning: Sparse CSR tensor support is in beta state. If you miss a functionality in the sparse tensor support, please submit a feature request to https://github.com/pytorch/pytorch/issues. (Triggered internally at /pytorch/aten/src/ATen/SparseCsrTensorImpl.cpp:53.)\n",
+      "\u001b[36m(RayTrainWorker pid=3352013)\u001b[0m   return torch.sparse_csr_tensor(\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "                                                                           \n",
+      "Epoch 0:   0%|          | 0/4160 [00:00<?, ?it/s] \n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "\u001b[36m(RayTrainWorker pid=3352013)\u001b[0m /tmp/ray/session_2025-09-29_16-21-57_025895_3287714/runtime_resources/working_dir_files/_ray_pkg_1da4f615a458d958/.venv/lib/python3.11/site-packages/lightning/pytorch/trainer/connectors/logger_connector/result.py:434: It is recommended to use `self.log('validation_loss', ..., sync_dist=True)` when logging on epoch level in distributed setting to accumulate the metric across devices.\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Epoch 0:   0%|          | 1/4160 [00:31<36:00:19,  0.03it/s, v_num=0, train_loss_step=3.970]\n",
+      "Epoch 0:   0%|          | 2/4160 [00:31<18:15:47,  0.06it/s, v_num=0, train_loss_step=3.490]\n",
+      "Epoch 0:   0%|          | 5/4160 [00:31<7:19:19,  0.16it/s, v_num=0, train_loss_step=2.810] \n",
+      ".\n",
+      ".\n",
+      ".\n",
+      "Epoch 0: 100%|█████████▉| 4142/4160 [05:12<00:01, 13.24it/s, v_num=0, train_loss_step=0.129] \n",
+      "Epoch 0: 100%|█████████▉| 4143/4160 [05:12<00:01, 13.24it/s, v_num=0, train_loss_step=0.0985]\n",
+      "Epoch 0: 100%|█████████▉| 4148/4160 [05:12<00:00, 13.25it/s, v_num=0, train_loss_step=0.153] \n",
+      "Epoch 0: 100%|█████████▉| 4149/4160 [05:13<00:00, 13.26it/s, v_num=0, train_loss_step=0.153]\n",
+      "Epoch 0: 100%|█████████▉| 4149/4160 [05:13<00:00, 13.25it/s, v_num=0, train_loss_step=0.115]\n",
+      "Epoch 0: 100%|█████████▉| 4154/4160 [05:13<00:00, 13.27it/s, v_num=0, train_loss_step=0.090] \n",
+      "Epoch 0: 100%|██████████| 4160/4160 [05:13<00:00, 13.28it/s, v_num=0, train_loss_step=0.121] \n",
+      "\u001b[36m(RayTrainWorker pid=3352013)\u001b[0m \n",
+      "Validation: |          | 0/? [00:00<?, ?it/s]\u001b[A\n",
+      "\u001b[36m(RayTrainWorker pid=3352013)\u001b[0m \n",
+      "Validation:   0%|          | 0/1024 [00:00<?, ?it/s]\u001b[A\n",
+      "Validation DataLoader 0:   0%|          | 0/1024 [00:00<?, ?it/s]\u001b[A\n",
+      "Validation DataLoader 0:   0%|          | 1/1024 [00:00<00:02, 361.89it/s]\u001b[A\n",
+      ".\n",
+      ".\n",
+      ".\n",
+      "Validation DataLoader 0: 100%|█████████▉| 1021/1024 [00:56<00:00, 18.10it/s]\u001b[A\n",
+      "\u001b[36m(RayTrainWorker pid=3352013)\u001b[0m \n",
+      "Validation DataLoader 0: 100%|█████████▉| 1022/1024 [00:56<00:00, 18.11it/s]\u001b[A\n",
+      "Validation DataLoader 0: 100%|█████████▉| 1023/1024 [00:56<00:00, 18.12it/s]\u001b[A\n",
+      "Validation DataLoader 0: 100%|██████████| 1024/1024 [00:56<00:00, 18.13it/s]\u001b[A\n",
+      "Epoch 0: 100%|██████████| 4160/4160 [06:38<00:00, 10.44it/s, v_num=0, train_loss_step=0.121]\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "\u001b[36m(RayTrainWorker pid=3352013)\u001b[0m /tmp/ray/session_2025-09-29_16-21-57_025895_3287714/runtime_resources/working_dir_files/_ray_pkg_1da4f615a458d958/.venv/lib/python3.11/site-packages/lightning/pytorch/trainer/connectors/logger_connector/result.py:434: It is recommended to use `self.log('train_loss', ..., sync_dist=True)` when logging on epoch level in distributed setting to accumulate the metric across devices.\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Epoch 0: 100%|██████████| 4160/4160 [06:38<00:00, 10.43it/s, v_num=0, train_loss_step=0.121, train_loss_epoch=0.180]\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "\u001b[36m(RayTrainWorker pid=3352013)\u001b[0m Checkpoint successfully created at: Checkpoint(filesystem=local, path=/home/dtran/protoplast_results/TorchTrainer_2025-09-29_16-22-48/TorchTrainer_89c02_00000_0_2025-09-29_16-22-48/checkpoint_000000)\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Epoch 0: 100%|██████████| 4160/4160 [06:39<00:00, 10.42it/s, v_num=0, train_loss_step=0.121, train_loss_epoch=0.180]\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "\u001b[36m(RayTrainWorker pid=3352013)\u001b[0m `Trainer.fit` stopped: `max_epochs=1` reached.\n",
+      "\u001b[36m(RayTrainWorker pid=3352013)\u001b[0m [rank0]:[W929 16:30:37.412533262 ProcessGroupNCCL.cpp:1538] Warning: WARNING: destroy_process_group() was not called before program exit, which can leak resources. For more info, please see https://pytorch.org/docs/stable/distributed.html#shutdown (function operator())\n"
+     ]
+    }
+   ],
+   "source": [
+    "%%time\n",
+    "ClassifierTrainingPlan_trainer = RayTrainRunner(\n",
+    "    Model=DistributedClassifierTrainingPlan,\n",
+    "    Ds=Dcl,\n",
+    "    model_keys=[\"classifier\", \"lr\", \"weight_decay\", \"eps\", \"optimizer\"],\n",
+    "    metadata_cb=clf_metadata_cb,\n",
+    ")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "c6dbfa49-e971-4ccf-ac3a-0cfdf9064274",
+   "metadata": {},
+   "source": [
+    "On a machine with **1 GPU (NVIDIA GeForce RTX 3080 - 12GiB) + 96 CPUs + 125GiB RAM**, `ClassifierTrainingPlan_trainer()` finished in **8 minutes**"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 19,
+   "id": "ffde478a-93ef-43b8-a7d9-03c9efd36ac1",
+   "metadata": {
+    "scrolled": true
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Setting thread_per_worker to half of the available CPUs capped at 4\n",
+      "Using 1 workers with {'CPU': 4} each\n",
+      "=========Length of val_split 65 length of test_split 0 length of train_split 262\n",
+      "=========Length of after dropping remainder val_split 64 length of test_split 0 length of train_split 260\n",
+      "Data splitting time: 23.91 seconds\n",
+      "Spawning Ray worker and initiating distributed training\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "2025-09-29 16:22:48,239\tINFO tune.py:616 -- [output] This uses the legacy output and progress reporter, as Jupyter notebooks are not supported by the new engine, yet. For more information, please see https://github.com/ray-project/ray/issues/36949\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "== Status ==\n",
+      "Current time: 2025-09-29 16:22:49 (running for 00:00:00.86)\n",
+      "Using FIFO scheduling algorithm.\n",
+      "Logical resource usage: 0/96 CPUs, 0/1 GPUs (0.0/1.0 accelerator_type:G)\n",
+      "Result logdir: /tmp/ray/session_2025-09-29_16-21-57_025895_3287714/artifacts/2025-09-29_16-22-48/TorchTrainer_2025-09-29_16-22-48/driver_artifacts\n",
+      "Number of trials: 1/1 (1 PENDING)\n",
+      "\n",
+      "\n",
+      "== Status ==\n",
+      "Current time: 2025-09-29 16:23:19 (running for 00:00:31.34)\n",
+      "Using FIFO scheduling algorithm.\n",
+      "Logical resource usage: 5.0/96 CPUs, 1.0/1 GPUs (0.0/1.0 accelerator_type:G)\n",
+      "Result logdir: /tmp/ray/session_2025-09-29_16-21-57_025895_3287714/artifacts/2025-09-29_16-22-48/TorchTrainer_2025-09-29_16-22-48/driver_artifacts\n",
+      "Number of trials: 1/1 (1 RUNNING)\n",
+      "\n",
+      "\n",
+      "== Status ==\n",
+      "Current time: 2025-09-29 16:30:36 (running for 00:07:48.74)\n",
+      "Using FIFO scheduling algorithm.\n",
+      "Logical resource usage: 5.0/96 CPUs, 1.0/1 GPUs (0.0/1.0 accelerator_type:G)\n",
+      "Result logdir: /tmp/ray/session_2025-09-29_16-21-57_025895_3287714/artifacts/2025-09-29_16-22-48/TorchTrainer_2025-09-29_16-22-48/driver_artifacts\n",
+      "Number of trials: 1/1 (1 RUNNING)\n",
+      "\n",
+      "\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "2025-09-29 16:30:38,727\tINFO tune.py:1009 -- Wrote the latest version of all result files and experiment state to '/home/dtran/protoplast_results/TorchTrainer_2025-09-29_16-22-48' in 1.7167s.\n",
+      "2025-09-29 16:30:38,792\tINFO tune.py:1041 -- Total run time: 470.55 seconds (468.75 seconds for the tuning loop).\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "== Status ==\n",
+      "Current time: 2025-09-29 16:30:38 (running for 00:07:50.48)\n",
+      "Using FIFO scheduling algorithm.\n",
+      "Logical resource usage: 5.0/96 CPUs, 1.0/1 GPUs (0.0/1.0 accelerator_type:G)\n",
+      "Result logdir: /tmp/ray/session_2025-09-29_16-21-57_025895_3287714/artifacts/2025-09-29_16-22-48/TorchTrainer_2025-09-29_16-22-48/driver_artifacts\n",
+      "Number of trials: 1/1 (1 TERMINATED)\n",
+      "\n",
+      "\n",
+      "CPU times: user 46.1 s, sys: 16.3 s, total: 1min 2s\n",
+      "Wall time: 8min 17s\n"
+     ]
+    }
+   ],
+   "source": [
+    "%%time\n",
+    "ClassifierTrainingPlan_trainer.train(\n",
+    "    file_paths,\n",
+    "    batch_size,  # 2000\n",
+    "    test_size,  # 0.0\n",
+    "    val_size,  # 0.2\n",
+    ")\n",
+    "ray.shutdown()"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "545e3313-beac-4d4f-8eb9-38a3033e2eb9",
+   "metadata": {},
+   "outputs": [],
+   "source": []
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3 (ipykernel)",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.11.13"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 5
 }

--- a/notebooks/perturbation_examples.ipynb
+++ b/notebooks/perturbation_examples.ipynb
@@ -1,1042 +1,948 @@
 {
-  "cells": [
-    {
-      "cell_type": "markdown",
-      "id": "MJUe",
-      "metadata": {},
-      "source": [
-        "# Perturbation Models for Single-Cell Data with PROTOplast"
-      ]
-    },
-    {
-      "cell_type": "markdown",
-      "id": "vblA",
-      "metadata": {},
-      "source": [
-        "This notebook showcases **perturbation models** for the **Tahoe-100M** dataset, focusing on predicting gene expression changes under drug perturbations. We demonstrate two approaches: a statistical baseline and a neural embedding model."
-      ]
-    },
-    {
-      "cell_type": "markdown",
-      "id": "d28a3cbd",
-      "metadata": {},
-      "source": [
-        "**Download the Tahoe-100M `h5ad` files**\n",
-        "- The Tahoe-100M dataset can be downloaded in `h5ad` format from the **Arc Institute Google Cloud Storage**. For step-by-step instructions, see the [official tutorial](https://github.com/ArcInstitute/arc-virtual-cell-atlas/blob/main/tahoe-100M/README.md)."
-      ]
-    },
-    {
-      "cell_type": "markdown",
-      "id": "bkHC",
-      "metadata": {},
-      "source": [
-        "**Set up**\n",
-        "- Set up the training environment for single-cell RNA sequencing (scRNA-seq) data using PROTOplast together with PyTorch Lightning and Ray"
-      ]
-    },
-    {
-      "cell_type": "code",
-      "execution_count": 1,
-      "id": "lEQa",
-      "metadata": {},
-      "outputs": [
-        {
-          "name": "stdout",
-          "output_type": "stream",
-          "text": [
-            "\u2713 Applied AnnDataFileManager patch\n"
-          ]
-        },
-        {
-          "name": "stderr",
-          "output_type": "stream",
-          "text": [
-            "/mnt/hdd1/dung/protoplast-ml-example/.venv/lib/python3.11/site-packages/tqdm/auto.py:21: TqdmWarning: IProgress not found. Please update jupyter and ipywidgets. See https://ipywidgets.readthedocs.io/en/stable/user_install.html\n",
-            "  from .autonotebook import tqdm as notebook_tqdm\n",
-            "2025-09-24 11:33:18,450\tINFO util.py:154 -- Missing packages: ['ipywidgets']. Run `pip install -U ipywidgets`, then restart the notebook server for rich notebook output.\n",
-            "2025-09-24 11:33:18,548\tINFO util.py:154 -- Missing packages: ['ipywidgets']. Run `pip install -U ipywidgets`, then restart the notebook server for rich notebook output.\n"
-          ]
-        },
-        {
-          "name": "stdout",
-          "output_type": "stream",
-          "text": [
-            "\u2713 Applied AnnDataFileManager patch\n"
-          ]
-        },
-        {
-          "name": "stderr",
-          "output_type": "stream",
-          "text": [
-            "2025-09-24 11:33:18,588\tINFO util.py:154 -- Missing packages: ['ipywidgets']. Run `pip install -U ipywidgets`, then restart the notebook server for rich notebook output.\n"
-          ]
-        }
-      ],
-      "source": [
-        "import anndata\n",
-        "import numpy as np\n",
-        "import torch\n",
-        "from protoplast.scrna.anndata.torch_dataloader import DistributedAnnDataset, cell_line_metadata_cb\n",
-        "from protoplast.scrna.anndata.trainer import RayTrainRunner\n",
-        "\n",
-        "# models from state\n",
-        "from state.tx.models.embed_sum import EmbedSumPerturbationModel\n",
-        "from state.tx.models.perturb_mean import PerturbMeanPerturbationModel"
-      ]
-    },
-    {
-      "cell_type": "markdown",
-      "id": "2bb6e3f3",
-      "metadata": {},
-      "source": [
-        "## 1. Load the Tahoe 100-M Dataset (`h5ad`)\n",
-        "- `file_paths`: here, only Plate 12 from Tahoe-100M (The largest file: 35 GB) is used as a demo. To add more plates, append their `.h5ad` file paths to the list, separated by commas\n",
-        "- `thread_per_worker`: number of threads allocated per worker\n",
-        "- `batch_size`: number of samples per training batch\n",
-        "- `test_size`: fraction of data reserved for testing\n",
-        "- `val_size`: fraction of data reserved for validation (use `0.0` if no validation set is needed)"
-      ]
-    },
-    {
-      "cell_type": "code",
-      "execution_count": 2,
-      "id": "Xref",
-      "metadata": {},
-      "outputs": [],
-      "source": [
-        "file_paths = [\"/mnt/hdd2/tan/tahoe100m/plate12_filt_Vevo_Tahoe100M_WServicesFrom_ParseGigalab.h5ad\"]\n",
-        "thread_per_worker = 2\n",
-        "batch_size = 2000\n",
-        "test_size = 0.0\n",
-        "val_size = 0.2"
-      ]
-    },
-    {
-      "cell_type": "markdown",
-      "id": "SFPL",
-      "metadata": {
-        "marimo": {
-          "config": {
-            "hide_code": true
-          }
-        }
-      },
-      "source": [
-        "## 2. Perturbation Mean\n",
-        "**PerturbMeanPerturbationModel** (from STATE) is a *statistical baseline* that predicts perturbed expression by combining a control baseline (global or per-sample) with a perturbation-specific offset averaged across cell types.\n",
-        "- **Inputs**\n",
-        "    - Perturbation identifier\n",
-        "    - Cell type (cell line in Tahoe-100M)\n",
-        "    - Perturbed counts or embeddings\n",
-        "    - (Optional) control embedding\n",
-        "- **Output**\n",
-        "    - Predicted gene expression profile (or latent embedding, depending on configuration)\n",
-        "Note: This model is not trained so no learnable weights, no validation data). Its predictions come purely from statistics of the training dataset. \n",
-        "**Source code:** [perturb_mean.py](https://github.com/ArcInstitute/state/blob/b6d26731e41d78c8c789d6973fe3d7db7853e9ad/src/state/tx/models/perturb_mean.py)"
-      ]
-    },
-    {
-      "cell_type": "markdown",
-      "id": "BYtC",
-      "metadata": {},
-      "source": [
-        "### Metadata Callback\n",
-        "The `perturbmean_metadata_cb` function prepares metadata for the **Perturbation Mean** model.  \n",
-        "- It converts drug and cell line columns to categorical values, sets input/output dimensions, hidden size, perturbation dimension, and training hyperparameters.  \n",
-        "- It also stores gene names, perturbation names, and cell types, while designating `DMSO_TF` as the control, `X` as the embedding key, and `gene` as the output space.\n",
-        "- `perturbmean_metadata_cb` prepares metadata for the Perturbation Mean model. It casts drug and cell line columns to categorical, sets input/output dimensions, hidden size, and perturbation dimension, and defines training hyperparameters. It also records gene names, perturbation names, and cell types, while specifying \"DMSO_TF\" as the control, \"X\" as the embedding key, and \"gene\" as the output space."
-      ]
-    },
-    {
-      "cell_type": "code",
-      "execution_count": 3,
-      "id": "RGSE",
-      "metadata": {},
-      "outputs": [
-        {
-          "name": "stdout",
-          "output_type": "stream",
-          "text": [
-            "CPU times: user 23 \u03bcs, sys: 0 ns, total: 23 \u03bcs\n",
-            "Wall time: 43.4 \u03bcs\n"
-          ]
-        }
-      ],
-      "source": [
-        "%%time\n",
-        "\n",
-        "\n",
-        "def perturbmean_metadata_cb(ad: anndata.AnnData, metadata: dict):\n",
-        "    ad.obs[\"drug\"] = ad.obs[\"drug\"].astype(\"category\")\n",
-        "    ad.obs[\"cell_line\"] = ad.obs[\"cell_line\"].astype(\"category\")\n",
-        "\n",
-        "    metadata[\"input_dim\"] = ad.var.shape[0]\n",
-        "    metadata[\"output_dim\"] = ad.var.shape[0]\n",
-        "    metadata[\"hidden_dim\"] = 0  # hidden_dim: Not used here, but required by base-class signature.\n",
-        "    metadata[\"pert_dim\"] = ad.obs[\"drug\"].astype(str).nunique()\n",
-        "    metadata[\"lr\"] = 1e-3\n",
-        "\n",
-        "    metadata[\"gene_names\"] = ad.var_names.tolist()\n",
-        "    metadata[\"pert_names\"] = ad.obs[\"drug\"].cat.categories.tolist()\n",
-        "    metadata[\"cell_types\"] = ad.obs[\"cell_line\"].cat.categories.tolist()\n",
-        "    metadata[\"control_pert\"] = \"DMSO_TF\"\n",
-        "    metadata[\"embed_key\"] = \"X\"\n",
-        "    metadata[\"output_space\"] = \"gene\""
-      ]
-    },
-    {
-      "cell_type": "markdown",
-      "id": "Kclp",
-      "metadata": {},
-      "source": [
-        "### Perturbation Dataset for Training (PerturbAnnDataset)\n",
-        "`PerturbAnnDataset` prepares batches for the **Perturbation Mean** model. It loads expression data, collects `drug` and `cell_line` metadata, and returns a dictionary containing perturbation names, cell types, and the corresponding expression features (used both as counts and embeddings) for training."
-      ]
-    },
-    {
-      "cell_type": "code",
-      "execution_count": 4,
-      "id": "emfo",
-      "metadata": {},
-      "outputs": [
-        {
-          "name": "stdout",
-          "output_type": "stream",
-          "text": [
-            "CPU times: user 149 \u03bcs, sys: 0 ns, total: 149 \u03bcs\n",
-            "Wall time: 170 \u03bcs\n"
-          ]
-        }
-      ],
-      "source": [
-        "%%time\n",
-        "\n",
-        "\n",
-        "class PerturbAnnDataset(DistributedAnnDataset):\n",
-        "    def transform(self, start: int, end: int):\n",
-        "        X = super().transform(start, end)\n",
-        "\n",
-        "        # Metadata froms self.ad\n",
-        "        pert_names = self.ad.obs[\"drug\"].iloc[start:end].astype(str).to_list()\n",
-        "        cell_lines = self.ad.obs[\"cell_line\"].iloc[start:end].astype(str).to_list()\n",
-        "\n",
-        "        return {\n",
-        "            \"pert_name\": pert_names,\n",
-        "            \"cell_type\": cell_lines,\n",
-        "            \"pert_cell_counts\": X,\n",
-        "            \"pert_cell_emb\": X,\n",
-        "        }"
-      ]
-    },
-    {
-      "cell_type": "markdown",
-      "id": "Hstk",
-      "metadata": {},
-      "source": [
-        "### Extending STATE Models\n",
-        "The **STATE** framework provides baseline model classes such as `PerturbMeanPerturbationModel`, which can be imported and used directly.\n",
-        "To customize behavior, you can **extend an existing class** and override only the methods that need modification.  \n",
-        "In the example below, we subclass `PerturbMeanPerturbationModel` and redefine the `forward()` method. Rather than relying on the per-cell `ctrl_cell_emb`, the model predicts using only the **global basal vector** combined with the corresponding perturbation offset."
-      ]
-    },
-    {
-      "cell_type": "code",
-      "execution_count": 5,
-      "id": "nWHF",
-      "metadata": {},
-      "outputs": [
-        {
-          "name": "stdout",
-          "output_type": "stream",
-          "text": [
-            "CPU times: user 135 \u03bcs, sys: 0 ns, total: 135 \u03bcs\n",
-            "Wall time: 156 \u03bcs\n"
-          ]
-        }
-      ],
-      "source": [
-        "%%time\n",
-        "\n",
-        "\n",
-        "class PerturbMeanGlobalModel(PerturbMeanPerturbationModel):\n",
-        "    \"\"\"\n",
-        "    Extended class of PerturbMeanPerturbationModel where prediction ignores\n",
-        "    per-cell control embedding and uses only global basal + offset.\n",
-        "    \"\"\"\n",
-        "\n",
-        "    def forward(self, batch: dict) -> torch.Tensor:\n",
-        "        B = len(batch[\"pert_name\"])\n",
-        "        device = self.dummy_param.device\n",
-        "        pred_out = torch.zeros((B, self.output_dim), device=device)\n",
-        "\n",
-        "        for i in range(B):\n",
-        "            p_name = str(batch[\"pert_name\"][i])\n",
-        "            offset_vec = self.pert_mean_offsets.get(p_name)\n",
-        "            if offset_vec is None:\n",
-        "                offset_vec = torch.zeros(self.output_dim, device=device)\n",
-        "\n",
-        "            # Use global basal instead of batch[\"ctrl_cell_emb\"]\n",
-        "            pred_out[i] = self.global_basal.to(device) + offset_vec.to(device)\n",
-        "\n",
-        "        return pred_out"
-      ]
-    },
-    {
-      "cell_type": "markdown",
-      "id": "af0e38aa",
-      "metadata": {},
-      "source": [
-        "### Training the model\n",
-        "- Collect statistics (`on_fit_start`)\n",
-        "    - Compute control means per cell type\n",
-        "    - Compute perturbation deltas\n",
-        "    - Average deltas across cell types \u2192 perturbation offsets\n",
-        "    - Compute global basal = mean of all control means.\n",
-        "- Forward: for each sample, `prediction = global_basal + offset[perturbation]`\n",
-        "- Training: no parameters are learned; only logs MSE loss vs. ground truth"
-      ]
-    },
-    {
-      "cell_type": "code",
-      "execution_count": 6,
-      "id": "iLit",
-      "metadata": {
-        "scrolled": true
-      },
-      "outputs": [
-        {
-          "name": "stderr",
-          "output_type": "stream",
-          "text": [
-            "2025-09-24 11:33:26,414\tINFO worker.py:1951 -- Started a local Ray instance.\n"
-          ]
-        },
-        {
-          "name": "stdout",
-          "output_type": "stream",
-          "text": [
-            "CPU times: user 232 ms, sys: 331 ms, total: 564 ms\n",
-            "Wall time: 2.81 s\n",
-            "\u001b[36m(TrainTrainable pid=1209221)\u001b[0m \u2713 Applied AnnDataFileManager patch\n",
-            "\u001b[36m(TrainTrainable pid=1209221)\u001b[0m \u2713 Applied AnnDataFileManager patch\n"
-          ]
-        },
-        {
-          "name": "stderr",
-          "output_type": "stream",
-          "text": [
-            "\u001b[36m(RayTrainWorker pid=1209389)\u001b[0m Setting up process group for: env:// [rank=0, world_size=1]\n",
-            "\u001b[36m(TorchTrainer pid=1209221)\u001b[0m Started distributed worker processes: \n",
-            "\u001b[36m(TorchTrainer pid=1209221)\u001b[0m - (node_id=3f1e363fcefb582b194b252798310b8d931ee304e5f7ccca2792aa00, ip=192.168.1.226, pid=1209389) world_rank=0, local_rank=0, node_rank=0\n"
-          ]
-        },
-        {
-          "name": "stdout",
-          "output_type": "stream",
-          "text": [
-            "\u001b[36m(RayTrainWorker pid=1209389)\u001b[0m \u2713 Applied AnnDataFileManager patch\n",
-            "\u001b[36m(RayTrainWorker pid=1209389)\u001b[0m \u2713 Applied AnnDataFileManager patch\n"
-          ]
-        },
-        {
-          "name": "stderr",
-          "output_type": "stream",
-          "text": [
-            "\u001b[36m(RayTrainWorker pid=1209389)\u001b[0m \ud83d\udca1 Tip: For seamless cloud uploads and versioning, try installing [litmodels](https://pypi.org/project/litmodels/) to enable LitModelCheckpoint, which syncs automatically with the Lightning model registry.\n",
-            "\u001b[36m(RayTrainWorker pid=1209389)\u001b[0m GPU available: True (cuda), used: True\n",
-            "\u001b[36m(RayTrainWorker pid=1209389)\u001b[0m TPU available: False, using: 0 TPU cores\n",
-            "\u001b[36m(RayTrainWorker pid=1209389)\u001b[0m HPU available: False, using: 0 HPUs\n",
-            "\u001b[36m(RayTrainWorker pid=1209389)\u001b[0m You are using a CUDA device ('NVIDIA GeForce RTX 3080') that has Tensor Cores. To properly utilize them, you should set `torch.set_float32_matmul_precision('medium' | 'high')` which will trade-off precision for performance. For more details, read https://pytorch.org/docs/stable/generated/torch.set_float32_matmul_precision.html#torch.set_float32_matmul_precision\n"
-          ]
-        },
-        {
-          "name": "stdout",
-          "output_type": "stream",
-          "text": [
-            "\u001b[36m(RayTrainWorker pid=1209389)\u001b[0m =========Starting the training on 0 with num threads: 2=========\n"
-          ]
-        },
-        {
-          "name": "stderr",
-          "output_type": "stream",
-          "text": [
-            "\u001b[36m(RayTrainWorker pid=1209389)\u001b[0m LOCAL_RANK: 0 - CUDA_VISIBLE_DEVICES: [0]\n",
-            "\u001b[36m(RayTrainWorker pid=1209389)\u001b[0m \n",
-            "\u001b[36m(RayTrainWorker pid=1209389)\u001b[0m   | Name         | Type    | Params | Mode \n",
-            "\u001b[36m(RayTrainWorker pid=1209389)\u001b[0m -------------------------------------------------\n",
-            "\u001b[36m(RayTrainWorker pid=1209389)\u001b[0m 0 | loss_fn      | MSELoss | 0      | train\n",
-            "\u001b[36m(RayTrainWorker pid=1209389)\u001b[0m   | other params | n/a     | 1      | n/a  \n",
-            "\u001b[36m(RayTrainWorker pid=1209389)\u001b[0m -------------------------------------------------\n",
-            "\u001b[36m(RayTrainWorker pid=1209389)\u001b[0m 1         Trainable params\n",
-            "\u001b[36m(RayTrainWorker pid=1209389)\u001b[0m 0         Non-trainable params\n",
-            "\u001b[36m(RayTrainWorker pid=1209389)\u001b[0m 1         Total params\n",
-            "\u001b[36m(RayTrainWorker pid=1209389)\u001b[0m 0.000     Total estimated model params size (MB)\n",
-            "\u001b[36m(RayTrainWorker pid=1209389)\u001b[0m 1         Modules in train mode\n",
-            "\u001b[36m(RayTrainWorker pid=1209389)\u001b[0m 0         Modules in eval mode\n"
-          ]
-        },
-        {
-          "name": "stdout",
-          "output_type": "stream",
-          "text": [
-            "Sanity Checking: |          | 0/? [00:00<?, ?it/s]\n",
-            "Sanity Checking DataLoader 0:   0%|          | 0/2 [00:00<?, ?it/s]\n",
-            "Sanity Checking DataLoader 0:  50%|\u2588\u2588\u2588\u2588\u2588     | 1/2 [00:00<00:00,  2.88it/s]\n",
-            "                                                                           \n",
-            "Epoch 0:   0%|          | 0/4192 [00:00<?, ?it/s] \n",
-            "Epoch 0:   0%|          | 1/4192 [00:22<26:32:38,  0.04it/s, v_num=0, train_loss=1.080]\n",
-            "Epoch 0:   0%|          | 2/4192 [00:23<13:48:53,  0.08it/s, v_num=0, train_loss=0.983]\n",
-            ".\n",
-            ".\n",
-            ".\n",
-            "Epoch 0: 100%|\u2588\u2588\u2588\u2588\u2588\u2588\u2588\u2588\u2588\u2589| 4190/4192 [23:06<00:00,  3.02it/s, v_num=0, train_loss=0.564]\n",
-            "Epoch 0: 100%|\u2588\u2588\u2588\u2588\u2588\u2588\u2588\u2588\u2588\u2589| 4191/4192 [23:07<00:00,  3.02it/s, v_num=0, train_loss=0.577]\n",
-            "Epoch 0: 100%|\u2588\u2588\u2588\u2588\u2588\u2588\u2588\u2588\u2588\u2588| 4192/4192 [23:07<00:00,  3.02it/s, v_num=0, train_loss=0.953]\n",
-            "\u001b[36m(RayTrainWorker pid=1209389)\u001b[0m \n",
-            "Validation: |          | 0/? [00:00<?, ?it/s]\u001b[A\n",
-            "\u001b[36m(RayTrainWorker pid=1209389)\u001b[0m \n",
-            "Validation:   0%|          | 0/1024 [00:00<?, ?it/s]\u001b[A\n",
-            "Validation DataLoader 0:   0%|          | 0/1024 [00:00<?, ?it/s]\u001b[A\n",
-            "\u001b[36m(RayTrainWorker pid=1209389)\u001b[0m \n",
-            ".\n",
-            ".\n",
-            ".\n",
-            "Validation DataLoader 0: 100%|\u2588\u2588\u2588\u2588\u2588\u2588\u2588\u2588\u2588\u2589| 1020/1024 [05:37<00:01,  3.02it/s]\u001b[A\n",
-            "\u001b[36m(RayTrainWorker pid=1209389)\u001b[0m \n",
-            "Validation DataLoader 0: 100%|\u2588\u2588\u2588\u2588\u2588\u2588\u2588\u2588\u2588\u2589| 1021/1024 [05:38<00:00,  3.02it/s]\u001b[A\n",
-            "\u001b[36m(RayTrainWorker pid=1209389)\u001b[0m \n",
-            "Validation DataLoader 0: 100%|\u2588\u2588\u2588\u2588\u2588\u2588\u2588\u2588\u2588\u2589| 1022/1024 [05:38<00:00,  3.02it/s]\u001b[A\n",
-            "\u001b[36m(RayTrainWorker pid=1209389)\u001b[0m \n",
-            "Validation DataLoader 0: 100%|\u2588\u2588\u2588\u2588\u2588\u2588\u2588\u2588\u2588\u2589| 1023/1024 [05:38<00:00,  3.02it/s]\u001b[A\n",
-            "\u001b[36m(RayTrainWorker pid=1209389)\u001b[0m \n",
-            "Validation DataLoader 0: 100%|\u2588\u2588\u2588\u2588\u2588\u2588\u2588\u2588\u2588\u2588| 1024/1024 [05:39<00:00,  3.02it/s]\u001b[A\n",
-            "Epoch 0: 100%|\u2588\u2588\u2588\u2588\u2588\u2588\u2588\u2588\u2588\u2588| 4192/4192 [29:09<00:00,  2.40it/s, v_num=0, train_loss=0.953]\n"
-          ]
-        },
-        {
-          "name": "stderr",
-          "output_type": "stream",
-          "text": [
-            "\u001b[36m(RayTrainWorker pid=1209389)\u001b[0m Checkpoint successfully created at: Checkpoint(filesystem=local, path=/home/dtran/protoplast_results/TorchTrainer_2025-09-24_11-33-51/TorchTrainer_58516_00000_0_2025-09-24_11-33-51/checkpoint_000000)\n"
-          ]
-        },
-        {
-          "name": "stdout",
-          "output_type": "stream",
-          "text": [
-            "Epoch 0: 100%|\u2588\u2588\u2588\u2588\u2588\u2588\u2588\u2588\u2588\u2588| 4192/4192 [29:09<00:00,  2.40it/s, v_num=0, train_loss=0.953]\n"
-          ]
-        },
-        {
-          "name": "stderr",
-          "output_type": "stream",
-          "text": [
-            "\u001b[36m(RayTrainWorker pid=1209389)\u001b[0m `Trainer.fit` stopped: `max_epochs=1` reached.\n"
-          ]
-        },
-        {
-          "name": "stdout",
-          "output_type": "stream",
-          "text": [
-            "Epoch 0: 100%|\u2588\u2588\u2588\u2588\u2588\u2588\u2588\u2588\u2588\u2588| 4192/4192 [29:09<00:00,  2.40it/s, v_num=0, train_loss=0.953]\n"
-          ]
-        },
-        {
-          "name": "stderr",
-          "output_type": "stream",
-          "text": [
-            "\u001b[36m(RayTrainWorker pid=1209389)\u001b[0m [rank0]:[W924 12:13:08.881254821 ProcessGroupNCCL.cpp:1538] Warning: WARNING: destroy_process_group() was not called before program exit, which can leak resources. For more info, please see https://pytorch.org/docs/stable/distributed.html#shutdown (function operator())\n"
-          ]
-        }
-      ],
-      "source": [
-        "%%time\n",
-        "PerturbMeanPerturbationModel_trainer = RayTrainRunner(\n",
-        "    PerturbMeanGlobalModel,\n",
-        "    PerturbAnnDataset,\n",
-        "    [\n",
-        "        \"input_dim\",\n",
-        "        \"output_dim\",\n",
-        "        \"hidden_dim\",\n",
-        "        \"pert_dim\",\n",
-        "        \"lr\",\n",
-        "        \"control_pert\",  # \"DMSO_TF\"\n",
-        "        \"embed_key\",\n",
-        "        \"output_space\",  # \"gene\"\n",
-        "    ],\n",
-        "    perturbmean_metadata_cb,\n",
-        ")"
-      ]
-    },
-    {
-      "cell_type": "markdown",
-      "id": "ae11ae35",
-      "metadata": {},
-      "source": [
-        "On a machine with **1 GPU (NVIDIA GeForce RTX 3080 - 12 GiB)**, **96 CPUs**, and **125 GiB RAM**, running `PerturbMeanPerturbationModel_trainer.train()` completed in approximately **40 minutes**."
-      ]
-    },
-    {
-      "cell_type": "code",
-      "execution_count": 7,
-      "id": "ZHCJ",
-      "metadata": {
-        "scrolled": true
-      },
-      "outputs": [
-        {
-          "name": "stdout",
-          "output_type": "stream",
-          "text": [
-            "Using 1 workers with {'CPU': 2} each\n",
-            "=========Length of val_split 65 length of test_split 0 length of train_split 262\n",
-            "=========Length of after dropping remainder val_split 64 length of test_split 0 length of train_split 262\n"
-          ]
-        },
-        {
-          "name": "stderr",
-          "output_type": "stream",
-          "text": [
-            "2025-09-24 11:33:51,717\tINFO tune.py:616 -- [output] This uses the legacy output and progress reporter, as Jupyter notebooks are not supported by the new engine, yet. For more information, please see https://github.com/ray-project/ray/issues/36949\n"
-          ]
-        },
-        {
-          "name": "stdout",
-          "output_type": "stream",
-          "text": [
-            "Data splitting time: 24.04 seconds\n",
-            "Spawning Ray worker and initiating distributed training\n",
-            "== Status ==\n",
-            "Current time: 2025-09-24 11:33:51 (running for 00:00:00.18)\n",
-            "Using FIFO scheduling algorithm.\n",
-            "Logical resource usage: 0/96 CPUs, 0/1 GPUs (0.0/1.0 accelerator_type:G)\n",
-            "Result logdir: /tmp/ray/session_2025-09-24_11-33-24_769318_1202711/artifacts/2025-09-24_11-33-51/TorchTrainer_2025-09-24_11-33-51/driver_artifacts\n",
-            "Number of trials: 1/1 (1 PENDING)\n",
-            "\n",
-            "\n",
-            "== Status ==\n",
-            "Current time: 2025-09-24 11:34:02 (running for 00:00:10.29)\n",
-            "Using FIFO scheduling algorithm.\n",
-            "Logical resource usage: 3.0/96 CPUs, 1.0/1 GPUs (0.0/1.0 accelerator_type:G)\n",
-            "Result logdir: /tmp/ray/session_2025-09-24_11-33-24_769318_1202711/artifacts/2025-09-24_11-33-51/TorchTrainer_2025-09-24_11-33-51/driver_artifacts\n",
-            "Number of trials: 1/1 (1 RUNNING)\n",
-            "\n",
-            "\n",
-            "== Status ==\n",
-            "Current time: 2025-09-24 12:13:05 (running for 00:39:14.00)\n",
-            "Using FIFO scheduling algorithm.\n",
-            "Logical resource usage: 3.0/96 CPUs, 1.0/1 GPUs (0.0/1.0 accelerator_type:G)\n",
-            "Result logdir: /tmp/ray/session_2025-09-24_11-33-24_769318_1202711/artifacts/2025-09-24_11-33-51/TorchTrainer_2025-09-24_11-33-51/driver_artifacts\n",
-            "Number of trials: 1/1 (1 RUNNING)\n",
-            "\n",
-            "\n"
-          ]
-        },
-        {
-          "name": "stderr",
-          "output_type": "stream",
-          "text": [
-            "2025-09-24 12:13:07,400\tINFO tune.py:1009 -- Wrote the latest version of all result files and experiment state to '/home/dtran/protoplast_results/TorchTrainer_2025-09-24_11-33-51' in 0.1191s.\n",
-            "2025-09-24 12:13:07,405\tINFO tune.py:1041 -- Total run time: 2355.69 seconds (2355.48 seconds for the tuning loop).\n"
-          ]
-        },
-        {
-          "name": "stdout",
-          "output_type": "stream",
-          "text": [
-            "== Status ==\n",
-            "Current time: 2025-09-24 12:13:07 (running for 00:39:15.60)\n",
-            "Using FIFO scheduling algorithm.\n",
-            "Logical resource usage: 3.0/96 CPUs, 1.0/1 GPUs (0.0/1.0 accelerator_type:G)\n",
-            "Result logdir: /tmp/ray/session_2025-09-24_11-33-24_769318_1202711/artifacts/2025-09-24_11-33-51/TorchTrainer_2025-09-24_11-33-51/driver_artifacts\n",
-            "Number of trials: 1/1 (1 TERMINATED)\n",
-            "\n",
-            "\n",
-            "CPU times: user 56.8 s, sys: 14.4 s, total: 1min 11s\n",
-            "Wall time: 39min 39s\n"
-          ]
-        },
-        {
-          "data": {
-            "text/plain": [
-              "Result(\n",
-              "  metrics={'train_loss': 0.9527178406715393, 'val_loss': 0.6070448756217957, 'epoch': 0, 'step': 4192},\n",
-              "  path='/home/dtran/protoplast_results/TorchTrainer_2025-09-24_11-33-51/TorchTrainer_58516_00000_0_2025-09-24_11-33-51',\n",
-              "  filesystem='local',\n",
-              "  checkpoint=Checkpoint(filesystem=local, path=/home/dtran/protoplast_results/TorchTrainer_2025-09-24_11-33-51/TorchTrainer_58516_00000_0_2025-09-24_11-33-51/checkpoint_000000)\n",
-              ")"
-            ]
-          },
-          "execution_count": 7,
-          "metadata": {},
-          "output_type": "execute_result"
-        }
-      ],
-      "source": [
-        "%%time\n",
-        "PerturbMeanPerturbationModel_trainer.train(\n",
-        "    file_paths,\n",
-        "    batch_size,  # 2000\n",
-        "    test_size,  # 0.0\n",
-        "    val_size,  # 0.2\n",
-        "    thread_per_worker=thread_per_worker,  # 2\n",
-        ")"
-      ]
-    },
-    {
-      "cell_type": "code",
-      "execution_count": 9,
-      "id": "fb929268-60a8-4650-89a2-f906e17e0abc",
-      "metadata": {},
-      "outputs": [],
-      "source": [
-        "import ray\n",
-        "\n",
-        "ray.shutdown()"
-      ]
-    },
-    {
-      "cell_type": "markdown",
-      "id": "ROlb",
-      "metadata": {},
-      "source": [
-        "## 3. EmbedSum\n",
-        "The **EmbedSumPerturbationModel** (part of the STATE framework) is a neural embedding model that predicts gene expression under perturbations.  \n",
-        "It works by combining a **control (basal) cell state** with a **learned perturbation embedding**.  \n",
-        "**Inputs**\n",
-        "  - Control (basal) expression counts or embedding  \n",
-        "  - Perturbation one-hot vector  \n",
-        "\n",
-        "**Output**\n",
-        "  - Predicted gene expression profile  \n",
-        "**Source code:** [embed_sum.py](https://github.com/ArcInstitute/state/blob/b6d26731e41d78c8c789d6973fe3d7db7853e9ad/src/state/tx/models/embed_sum.py#L7)"
-      ]
-    },
-    {
-      "cell_type": "markdown",
-      "id": "qnkX",
-      "metadata": {},
-      "source": [
-        "### Metadata Callback\n",
-        "The `embedsum_metadata_cb` function prepares metadata for the `EmbedSumPerturbationModel`. It sets the input and output dimensions (equal to the **number of genes**), defines the perturbation dimension based on the unique drugs in the dataset, and specifies training parameters such as hidden layer size and the control perturbation (`DMSO_TF`)."
-      ]
-    },
-    {
-      "cell_type": "code",
-      "execution_count": 10,
-      "id": "TqIu",
-      "metadata": {},
-      "outputs": [
-        {
-          "name": "stdout",
-          "output_type": "stream",
-          "text": [
-            "CPU times: user 18 \u03bcs, sys: 4 \u03bcs, total: 22 \u03bcs\n",
-            "Wall time: 34.3 \u03bcs\n"
-          ]
-        }
-      ],
-      "source": [
-        "%%time\n",
-        "\n",
-        "\n",
-        "def embedsum_metadata_cb(ad: anndata.AnnData, metadata: dict):\n",
-        "    cell_line_metadata_cb(ad, metadata)\n",
-        "    metadata[\"input_dim\"] = ad.var.shape[0]\n",
-        "    metadata[\"output_dim\"] = ad.var.shape[0]\n",
-        "\n",
-        "    uniq_drugs = sorted(ad.obs[\"drug\"].astype(str).unique().tolist())\n",
-        "    metadata[\"pert_dim\"] = len(uniq_drugs)\n",
-        "\n",
-        "    metadata[\"hidden_dim\"] = 10  # here kept small for testing\n",
-        "    metadata[\"control_pert\"] = \"DMSO_TF\""
-      ]
-    },
-    {
-      "cell_type": "markdown",
-      "id": "Vxnm",
-      "metadata": {},
-      "source": [
-        "### EmbedSumAnnDataset\n",
-        "The `EmbedSumAnnDataset` class extends `DistributedAnnDataset` and prepares batches for the `EmbedSumPerturbationModel`. It enriches each batch with drug embeddings, metadata, and control information needed for training."
-      ]
-    },
-    {
-      "cell_type": "code",
-      "execution_count": 12,
-      "id": "DnEU",
-      "metadata": {},
-      "outputs": [
-        {
-          "name": "stdout",
-          "output_type": "stream",
-          "text": [
-            "CPU times: user 144 \u03bcs, sys: 0 ns, total: 144 \u03bcs\n",
-            "Wall time: 158 \u03bcs\n"
-          ]
-        }
-      ],
-      "source": [
-        "%%time\n",
-        "\n",
-        "\n",
-        "class EmbedSumAnnDataset(DistributedAnnDataset):\n",
-        "    control_drug = \"DMSO_TF\"\n",
-        "\n",
-        "    def transform(self, start: int, end: int):\n",
-        "        # Loads gene expression (X) and converts it into a tensor (target_gene_expr).\n",
-        "        X = super().transform(start, end)\n",
-        "        target_gene_expr = torch.as_tensor(X, dtype=torch.float32)\n",
-        "        device = target_gene_expr.device\n",
-        "\n",
-        "        # Collects metadata: perturbation names (drug) and cell line labels\n",
-        "        pert_names = self.ad.obs[\"drug\"].iloc[start:end].astype(str).to_list()\n",
-        "        cell_lines = self.ad.obs[\"cell_line\"].iloc[start:end].astype(str).to_list()\n",
-        "\n",
-        "        # Create drug index mapping\n",
-        "        if not hasattr(self, \"_drug_to_idx\"):\n",
-        "            drug_names = sorted(self.ad.obs[\"drug\"].astype(str).unique())\n",
-        "            self._drug_to_idx = {d: i for i, d in enumerate(drug_names)}\n",
-        "            self._num_drugs = len(drug_names)\n",
-        "\n",
-        "        # encodes drugs as one-hot embeddings\n",
-        "        idxs = [self._drug_to_idx.get(p, 0) for p in pert_names]\n",
-        "        pert_emb = torch.nn.functional.one_hot(torch.tensor(idxs, device=device), num_classes=self._num_drugs).float()\n",
-        "\n",
-        "        # Computes a global control mean expression vector from cells treated with DMSO_TF\n",
-        "        if not hasattr(self, \"_ctrl_global\"):\n",
-        "            mask = self.ad.obs[\"drug\"] == self.control_drug\n",
-        "            if mask.sum() == 0:\n",
-        "                ctrl_vec = np.zeros(self.ad.shape[1], dtype=np.float32)\n",
-        "            else:\n",
-        "                ctrl_vec = np.asarray(self.ad[mask].X.mean(axis=0)).ravel().astype(np.float32)\n",
-        "            self._ctrl_global = torch.from_numpy(ctrl_vec)\n",
-        "\n",
-        "        ctrl_cell_emb = self._ctrl_global.to(device).unsqueeze(0).expand(len(pert_names), -1)\n",
-        "\n",
-        "        # Returns a dictionary containing embeddings, control features, target expression, and metadata for perturbation training\n",
-        "        return {\n",
-        "            \"pert_emb\": pert_emb,\n",
-        "            \"ctrl_cell_emb\": ctrl_cell_emb,\n",
-        "            \"target_gene_expr\": target_gene_expr,\n",
-        "            \"pert_cell_emb\": target_gene_expr,\n",
-        "            \"pert_name\": pert_names,\n",
-        "            \"cell_type\": cell_lines,\n",
-        "        }"
-      ]
-    },
-    {
-      "cell_type": "markdown",
-      "id": "ulZA",
-      "metadata": {},
-      "source": [
-        "### Training the EmbedSumPerturbationModel\n",
-        "- It pairs the model with the custom `EmbedSumAnnDataset` and passes in required arguments (dimensions, learning rate, control perturbation, embedding key, and output space) via `embedsum_metadata_cb`."
-      ]
-    },
-    {
-      "cell_type": "code",
-      "execution_count": 13,
-      "id": "ecfG",
-      "metadata": {
-        "scrolled": true
-      },
-      "outputs": [
-        {
-          "name": "stderr",
-          "output_type": "stream",
-          "text": [
-            "2025-09-24 12:14:53,176\tINFO worker.py:1951 -- Started a local Ray instance.\n"
-          ]
-        },
-        {
-          "name": "stdout",
-          "output_type": "stream",
-          "text": [
-            "CPU times: user 112 ms, sys: 301 ms, total: 412 ms\n",
-            "Wall time: 3.66 s\n",
-            "\u001b[36m(TrainTrainable pid=1251740)\u001b[0m \u2713 Applied AnnDataFileManager patch\n",
-            "\u001b[36m(TrainTrainable pid=1251740)\u001b[0m \u2713 Applied AnnDataFileManager patch\n"
-          ]
-        },
-        {
-          "name": "stderr",
-          "output_type": "stream",
-          "text": [
-            "\u001b[36m(RayTrainWorker pid=1252096)\u001b[0m Setting up process group for: env:// [rank=0, world_size=1]\n",
-            "\u001b[36m(TorchTrainer pid=1251740)\u001b[0m Started distributed worker processes: \n",
-            "\u001b[36m(TorchTrainer pid=1251740)\u001b[0m - (node_id=76088a489aa8c92b9eeb053e2cee79abba9656a0d134181ab362cea8, ip=192.168.1.226, pid=1252096) world_rank=0, local_rank=0, node_rank=0\n"
-          ]
-        },
-        {
-          "name": "stdout",
-          "output_type": "stream",
-          "text": [
-            "\u001b[36m(RayTrainWorker pid=1252096)\u001b[0m \u2713 Applied AnnDataFileManager patch\n",
-            "\u001b[36m(RayTrainWorker pid=1252096)\u001b[0m \u2713 Applied AnnDataFileManager patch\n",
-            "\u001b[36m(RayTrainWorker pid=1252096)\u001b[0m =========Starting the training on 0 with num threads: 2=========\n"
-          ]
-        },
-        {
-          "name": "stderr",
-          "output_type": "stream",
-          "text": [
-            "\u001b[36m(RayTrainWorker pid=1252096)\u001b[0m \ud83d\udca1 Tip: For seamless cloud uploads and versioning, try installing [litmodels](https://pypi.org/project/litmodels/) to enable LitModelCheckpoint, which syncs automatically with the Lightning model registry.\n",
-            "\u001b[36m(RayTrainWorker pid=1252096)\u001b[0m GPU available: True (cuda), used: True\n",
-            "\u001b[36m(RayTrainWorker pid=1252096)\u001b[0m TPU available: False, using: 0 TPU cores\n",
-            "\u001b[36m(RayTrainWorker pid=1252096)\u001b[0m HPU available: False, using: 0 HPUs\n",
-            "\u001b[36m(RayTrainWorker pid=1252096)\u001b[0m You are using a CUDA device ('NVIDIA GeForce RTX 3080') that has Tensor Cores. To properly utilize them, you should set `torch.set_float32_matmul_precision('medium' | 'high')` which will trade-off precision for performance. For more details, read https://pytorch.org/docs/stable/generated/torch.set_float32_matmul_precision.html#torch.set_float32_matmul_precision\n",
-            "\u001b[36m(RayTrainWorker pid=1252096)\u001b[0m LOCAL_RANK: 0 - CUDA_VISIBLE_DEVICES: [0]\n",
-            "\u001b[36m(RayTrainWorker pid=1252096)\u001b[0m \n",
-            "\u001b[36m(RayTrainWorker pid=1252096)\u001b[0m   | Name          | Type       | Params | Mode \n",
-            "\u001b[36m(RayTrainWorker pid=1252096)\u001b[0m -----------------------------------------------------\n",
-            "\u001b[36m(RayTrainWorker pid=1252096)\u001b[0m 0 | loss_fn       | MSELoss    | 0      | train\n",
-            "\u001b[36m(RayTrainWorker pid=1252096)\u001b[0m 1 | pert_encoder  | Sequential | 1.1 K  | train\n",
-            "\u001b[36m(RayTrainWorker pid=1252096)\u001b[0m 2 | basal_encoder | Sequential | 627 K  | train\n",
-            "\u001b[36m(RayTrainWorker pid=1252096)\u001b[0m 3 | project_out   | Sequential | 689 K  | train\n",
-            "\u001b[36m(RayTrainWorker pid=1252096)\u001b[0m -----------------------------------------------------\n",
-            "\u001b[36m(RayTrainWorker pid=1252096)\u001b[0m 1.3 M     Trainable params\n",
-            "\u001b[36m(RayTrainWorker pid=1252096)\u001b[0m 0         Non-trainable params\n",
-            "\u001b[36m(RayTrainWorker pid=1252096)\u001b[0m 1.3 M     Total params\n",
-            "\u001b[36m(RayTrainWorker pid=1252096)\u001b[0m 5.273     Total estimated model params size (MB)\n",
-            "\u001b[36m(RayTrainWorker pid=1252096)\u001b[0m 16        Modules in train mode\n",
-            "\u001b[36m(RayTrainWorker pid=1252096)\u001b[0m 0         Modules in eval mode\n"
-          ]
-        },
-        {
-          "name": "stdout",
-          "output_type": "stream",
-          "text": [
-            "Sanity Checking: |          | 0/? [00:00<?, ?it/s]\n",
-            "Sanity Checking DataLoader 0:   0%|          | 0/2 [00:00<?, ?it/s]\n",
-            "Sanity Checking DataLoader 0:  50%|\u2588\u2588\u2588\u2588\u2588     | 1/2 [00:00<00:00,  1.70it/s]\n",
-            "                                                                           \n",
-            "Epoch 0:   0%|          | 0/4192 [00:00<?, ?it/s] \n",
-            "Epoch 0:   0%|          | 1/4192 [00:43<50:46:34,  0.02it/s, v_num=0]\n",
-            ".\n",
-            ".\n",
-            ".\n",
-            "Epoch 0: 100%|\u2588\u2588\u2588\u2588\u2588\u2588\u2588\u2588\u2588\u2589| 4190/4192 [26:49<00:00,  2.60it/s, v_num=0]\n",
-            "Epoch 0: 100%|\u2588\u2588\u2588\u2588\u2588\u2588\u2588\u2588\u2588\u2589| 4191/4192 [26:49<00:00,  2.60it/s, v_num=0]\n",
-            "Epoch 0: 100%|\u2588\u2588\u2588\u2588\u2588\u2588\u2588\u2588\u2588\u2588| 4192/4192 [26:50<00:00,  2.60it/s, v_num=0]\n",
-            "\u001b[36m(RayTrainWorker pid=1252096)\u001b[0m \n",
-            "Validation: |          | 0/? [00:00<?, ?it/s]\u001b[A\n",
-            "\u001b[36m(RayTrainWorker pid=1252096)\u001b[0m \n",
-            "Validation:   0%|          | 0/1024 [00:00<?, ?it/s]\u001b[A\n",
-            "Validation DataLoader 0:   0%|          | 0/1024 [00:00<?, ?it/s]\u001b[A\n",
-            "Validation DataLoader 0:   0%|          | 1/1024 [00:00<00:07, 136.59it/s]\u001b[A\n",
-            "\u001b[36m(RayTrainWorker pid=1252096)\u001b[0m \n",
-            ".\n",
-            ".\n",
-            ".\n",
-            "Validation DataLoader 0: 100%|\u2588\u2588\u2588\u2588\u2588\u2588\u2588\u2588\u2588\u2589| 1022/1024 [06:19<00:00,  2.69it/s]\u001b[A\n",
-            "\u001b[36m(RayTrainWorker pid=1252096)\u001b[0m \n",
-            "Validation DataLoader 0: 100%|\u2588\u2588\u2588\u2588\u2588\u2588\u2588\u2588\u2588\u2589| 1023/1024 [06:19<00:00,  2.69it/s]\u001b[A\n",
-            "\u001b[36m(RayTrainWorker pid=1252096)\u001b[0m \n",
-            "Validation DataLoader 0: 100%|\u2588\u2588\u2588\u2588\u2588\u2588\u2588\u2588\u2588\u2588| 1024/1024 [06:19<00:00,  2.69it/s]\u001b[A\n",
-            "Epoch 0: 100%|\u2588\u2588\u2588\u2588\u2588\u2588\u2588\u2588\u2588\u2588| 4192/4192 [33:31<00:00,  2.08it/s, v_num=0]       \u001b[A\n",
-            "Epoch 0: 100%|\u2588\u2588\u2588\u2588\u2588\u2588\u2588\u2588\u2588\u2588| 4192/4192 [33:32<00:00,  2.08it/s, v_num=0]\n"
-          ]
-        },
-        {
-          "name": "stderr",
-          "output_type": "stream",
-          "text": [
-            "\u001b[36m(RayTrainWorker pid=1252096)\u001b[0m Checkpoint successfully created at: Checkpoint(filesystem=local, path=/home/dtran/protoplast_results/TorchTrainer_2025-09-24_12-15-18/TorchTrainer_22951_00000_0_2025-09-24_12-15-18/checkpoint_000000)\n",
-            "\u001b[36m(RayTrainWorker pid=1252096)\u001b[0m `Trainer.fit` stopped: `max_epochs=1` reached.\n"
-          ]
-        },
-        {
-          "name": "stdout",
-          "output_type": "stream",
-          "text": [
-            "Epoch 0: 100%|\u2588\u2588\u2588\u2588\u2588\u2588\u2588\u2588\u2588\u2588| 4192/4192 [33:32<00:00,  2.08it/s, v_num=0]\n"
-          ]
-        },
-        {
-          "name": "stderr",
-          "output_type": "stream",
-          "text": [
-            "\u001b[36m(RayTrainWorker pid=1252096)\u001b[0m [rank0]:[W924 12:49:54.699038949 ProcessGroupNCCL.cpp:1538] Warning: WARNING: destroy_process_group() was not called before program exit, which can leak resources. For more info, please see https://pytorch.org/docs/stable/distributed.html#shutdown (function operator())\n"
-          ]
-        }
-      ],
-      "source": [
-        "%%time\n",
-        "EmbedSumPerturbationModel_trainer = RayTrainRunner(\n",
-        "    EmbedSumPerturbationModel,\n",
-        "    EmbedSumAnnDataset,\n",
-        "    [\n",
-        "        \"input_dim\",\n",
-        "        \"output_dim\",\n",
-        "        \"hidden_dim\",\n",
-        "        \"pert_dim\",\n",
-        "        \"lr\",\n",
-        "        \"control_pert\",  # \"DMSO_TF\"\n",
-        "        \"embed_key\",\n",
-        "        \"output_space\",  # \"gene\"\n",
-        "    ],\n",
-        "    embedsum_metadata_cb,\n",
-        ")"
-      ]
-    },
-    {
-      "cell_type": "markdown",
-      "id": "77ff4544",
-      "metadata": {},
-      "source": [
-        "On a machine with **1 GPU (NVIDIA GeForce RTX 3080 - 12 GiB)**, **96 CPUs**, and **125 GiB RAM**, running `EmbedSumPerturbationModel_trainer.train()` completed in approximately **35 minutes**."
-      ]
-    },
-    {
-      "cell_type": "code",
-      "execution_count": 14,
-      "id": "Pvdt",
-      "metadata": {
-        "scrolled": true
-      },
-      "outputs": [
-        {
-          "name": "stdout",
-          "output_type": "stream",
-          "text": [
-            "Using 1 workers with {'CPU': 2} each\n",
-            "=========Length of val_split 65 length of test_split 0 length of train_split 262\n",
-            "=========Length of after dropping remainder val_split 64 length of test_split 0 length of train_split 262\n"
-          ]
-        },
-        {
-          "name": "stderr",
-          "output_type": "stream",
-          "text": [
-            "2025-09-24 12:15:18,559\tINFO tune.py:616 -- [output] This uses the legacy output and progress reporter, as Jupyter notebooks are not supported by the new engine, yet. For more information, please see https://github.com/ray-project/ray/issues/36949\n"
-          ]
-        },
-        {
-          "name": "stdout",
-          "output_type": "stream",
-          "text": [
-            "Data splitting time: 24.34 seconds\n",
-            "Spawning Ray worker and initiating distributed training\n",
-            "== Status ==\n",
-            "Current time: 2025-09-24 12:15:18 (running for 00:00:00.12)\n",
-            "Using FIFO scheduling algorithm.\n",
-            "Logical resource usage: 0/96 CPUs, 0/1 GPUs (0.0/1.0 accelerator_type:G)\n",
-            "Result logdir: /tmp/ray/session_2025-09-24_12-14-50_582135_1202711/artifacts/2025-09-24_12-15-18/TorchTrainer_2025-09-24_12-15-18/driver_artifacts\n",
-            "Number of trials: 1/1 (1 PENDING)\n",
-            "\n",
-            "\n",
-            "== Status ==\n",
-            "Current time: 2025-09-24 12:15:28 (running for 00:00:10.24)\n",
-            "Using FIFO scheduling algorithm.\n",
-            "Logical resource usage: 3.0/96 CPUs, 1.0/1 GPUs (0.0/1.0 accelerator_type:G)\n",
-            "Result logdir: /tmp/ray/session_2025-09-24_12-14-50_582135_1202711/artifacts/2025-09-24_12-15-18/TorchTrainer_2025-09-24_12-15-18/driver_artifacts\n",
-            "Number of trials: 1/1 (1 RUNNING)\n",
-            "\n",
-            "\n",
-            "== Status ==\n",
-            "Current time: 2025-09-24 12:49:52 (running for 00:34:33.77)\n",
-            "Using FIFO scheduling algorithm.\n",
-            "Logical resource usage: 3.0/96 CPUs, 1.0/1 GPUs (0.0/1.0 accelerator_type:G)\n",
-            "Result logdir: /tmp/ray/session_2025-09-24_12-14-50_582135_1202711/artifacts/2025-09-24_12-15-18/TorchTrainer_2025-09-24_12-15-18/driver_artifacts\n",
-            "Number of trials: 1/1 (1 RUNNING)\n",
-            "\n",
-            "\n"
-          ]
-        },
-        {
-          "name": "stderr",
-          "output_type": "stream",
-          "text": [
-            "2025-09-24 12:49:52,903\tINFO tune.py:1009 -- Wrote the latest version of all result files and experiment state to '/home/dtran/protoplast_results/TorchTrainer_2025-09-24_12-15-18' in 0.0066s.\n",
-            "2025-09-24 12:49:52,908\tINFO tune.py:1041 -- Total run time: 2074.35 seconds (2074.32 seconds for the tuning loop).\n"
-          ]
-        },
-        {
-          "name": "stdout",
-          "output_type": "stream",
-          "text": [
-            "== Status ==\n",
-            "Current time: 2025-09-24 12:49:52 (running for 00:34:34.33)\n",
-            "Using FIFO scheduling algorithm.\n",
-            "Logical resource usage: 3.0/96 CPUs, 1.0/1 GPUs (0.0/1.0 accelerator_type:G)\n",
-            "Result logdir: /tmp/ray/session_2025-09-24_12-14-50_582135_1202711/artifacts/2025-09-24_12-15-18/TorchTrainer_2025-09-24_12-15-18/driver_artifacts\n",
-            "Number of trials: 1/1 (1 TERMINATED)\n",
-            "\n",
-            "\n",
-            "CPU times: user 50.9 s, sys: 10.9 s, total: 1min 1s\n",
-            "Wall time: 34min 58s\n"
-          ]
-        },
-        {
-          "data": {
-            "text/plain": [
-              "Result(\n",
-              "  metrics={'train_loss': 1.076431155204773, 'val_loss': 0.628422200679779, 'epoch': 0, 'step': 4192},\n",
-              "  path='/home/dtran/protoplast_results/TorchTrainer_2025-09-24_12-15-18/TorchTrainer_22951_00000_0_2025-09-24_12-15-18',\n",
-              "  filesystem='local',\n",
-              "  checkpoint=Checkpoint(filesystem=local, path=/home/dtran/protoplast_results/TorchTrainer_2025-09-24_12-15-18/TorchTrainer_22951_00000_0_2025-09-24_12-15-18/checkpoint_000000)\n",
-              ")"
-            ]
-          },
-          "execution_count": 14,
-          "metadata": {},
-          "output_type": "execute_result"
-        },
-        {
-          "name": "stderr",
-          "output_type": "stream",
-          "text": [
-            "*** SIGTERM received at time=1758718221 on cpu 9 ***\n",
-            "PC: @     0x73f02e32a072  (unknown)  epoll_wait\n",
-            "    @     0x73f02e245330  (unknown)  (unknown)\n",
-            "    @     0x5a1f48e9565a  (unknown)  select_epoll_poll_impl\n",
-            "[2025-09-24 12:50:21,507 E 1202711 1202711] logging.cc:474: *** SIGTERM received at time=1758718221 on cpu 9 ***\n",
-            "[2025-09-24 12:50:21,507 E 1202711 1202711] logging.cc:474: PC: @     0x73f02e32a072  (unknown)  epoll_wait\n",
-            "[2025-09-24 12:50:21,508 E 1202711 1202711] logging.cc:474:     @     0x73f02e245330  (unknown)  (unknown)\n",
-            "[2025-09-24 12:50:21,508 E 1202711 1202711] logging.cc:474:     @     0x5a1f48e9565a  (unknown)  select_epoll_poll_impl\n"
-          ]
-        }
-      ],
-      "source": [
-        "%%time\n",
-        "EmbedSumPerturbationModel_trainer.train(\n",
-        "    file_paths,\n",
-        "    batch_size,  # 2000\n",
-        "    test_size,  # 0.0\n",
-        "    val_size,  # 0.2\n",
-        "    thread_per_worker=thread_per_worker,  # 2\n",
-        ")"
-      ]
-    },
-    {
-      "cell_type": "code",
-      "execution_count": null,
-      "id": "8e6af2a3-ec4d-4b19-a839-5c179067b846",
-      "metadata": {},
-      "outputs": [],
-      "source": []
-    }
-  ],
-  "metadata": {
-    "kernelspec": {
-      "display_name": "Python (protoplast-ml-example)",
-      "language": "python",
-      "name": "protoplast-ml-example"
-    },
-    "language_info": {
-      "codemirror_mode": {
-        "name": "ipython",
-        "version": 3
-      },
-      "file_extension": ".py",
-      "mimetype": "text/x-python",
-      "name": "python",
-      "nbconvert_exporter": "python",
-      "pygments_lexer": "ipython3",
-      "version": "3.11.13"
-    }
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "id": "MJUe",
+   "metadata": {},
+   "source": [
+    "# Perturbation Models for Single-Cell Data with PROTOplast"
+   ]
   },
-  "nbformat": 4,
-  "nbformat_minor": 5
+  {
+   "cell_type": "markdown",
+   "id": "vblA",
+   "metadata": {},
+   "source": [
+    "This notebook showcases **perturbation models** for the **Tahoe-100M** dataset, focusing on predicting gene expression changes under drug perturbations. We demonstrate two approaches: a statistical baseline and a neural embedding model."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "d28a3cbd",
+   "metadata": {},
+   "source": [
+    "**Download the Tahoe-100M `h5ad` files**\n",
+    "- The Tahoe-100M dataset can be downloaded in `h5ad` format from the **Arc Institute Google Cloud Storage**. For step-by-step instructions, see the [official tutorial](https://github.com/ArcInstitute/arc-virtual-cell-atlas/blob/main/tahoe-100M/README.md)."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "bkHC",
+   "metadata": {},
+   "source": [
+    "**Set up**\n",
+    "- Set up the training environment for single-cell RNA sequencing (scRNA-seq) data using PROTOplast together with PyTorch Lightning and Ray"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 1,
+   "id": "lEQa",
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "✓ Applied AnnDataFileManager patch, AnnData cannot be imported after the patch!\n",
+      "✓ Applied AnnDataFileManager patch, AnnData cannot be imported after the patch!\n"
+     ]
+    }
+   ],
+   "source": [
+    "import anndata\n",
+    "import numpy as np\n",
+    "import torch\n",
+    "from protoplast.scrna.anndata.torch_dataloader import DistributedAnnDataset, cell_line_metadata_cb\n",
+    "from protoplast.scrna.anndata.trainer import RayTrainRunner\n",
+    "\n",
+    "# models from state\n",
+    "from state.tx.models.embed_sum import EmbedSumPerturbationModel\n",
+    "from state.tx.models.perturb_mean import PerturbMeanPerturbationModel"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "2bb6e3f3",
+   "metadata": {},
+   "source": [
+    "## 1. Load the Tahoe 100-M Dataset (`h5ad`)\n",
+    "- `file_paths`: here, only Plate 12 from Tahoe-100M (The largest file: 35 GB) is used as a demo. To add more plates, append their `.h5ad` file paths to the list, separated by commas\n",
+    "- `batch_size`: number of samples per training batch\n",
+    "- `test_size`: fraction of data reserved for testing\n",
+    "- `val_size`: fraction of data reserved for validation (use `0.0` if no validation set is needed)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 2,
+   "id": "Xref",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "file_paths = [\"/mnt/hdd2/tan/tahoe100m/plate12_filt_Vevo_Tahoe100M_WServicesFrom_ParseGigalab.h5ad\"]\n",
+    "batch_size = 2000\n",
+    "test_size = 0.0\n",
+    "val_size = 0.2"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "SFPL",
+   "metadata": {
+    "marimo": {
+     "config": {
+      "hide_code": true
+     }
+    }
+   },
+   "source": [
+    "## 2. Perturbation Mean\n",
+    "**PerturbMeanPerturbationModel** (from STATE) is a *statistical baseline* that predicts perturbed expression by combining a control baseline (global or per-sample) with a perturbation-specific offset averaged across cell types.\n",
+    "- **Inputs**\n",
+    "    - Perturbation identifier\n",
+    "    - Cell type (cell line in Tahoe-100M)\n",
+    "    - Perturbed counts or embeddings\n",
+    "    - (Optional) control embedding\n",
+    "- **Output**\n",
+    "    - Predicted gene expression profile (or latent embedding, depending on configuration)\n",
+    "Note: This model is not trained so no learnable weights, no validation data). Its predictions come purely from statistics of the training dataset. \n",
+    "**Source code:** [perturb_mean.py](https://github.com/ArcInstitute/state/blob/b6d26731e41d78c8c789d6973fe3d7db7853e9ad/src/state/tx/models/perturb_mean.py)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "BYtC",
+   "metadata": {},
+   "source": [
+    "### Metadata Callback\n",
+    "The `perturbmean_metadata_cb` function prepares metadata for the **Perturbation Mean** model.  \n",
+    "- It converts drug and cell line columns to categorical values, sets input/output dimensions, hidden size, perturbation dimension, and training hyperparameters.  \n",
+    "- It also stores gene names, perturbation names, and cell types, while designating `DMSO_TF` as the control, `X` as the embedding key, and `gene` as the output space.\n",
+    "- `perturbmean_metadata_cb` prepares metadata for the Perturbation Mean model. It casts drug and cell line columns to categorical, sets input/output dimensions, hidden size, and perturbation dimension, and defines training hyperparameters. It also records gene names, perturbation names, and cell types, while specifying `DMSO_TF` as the control, `X` as the embedding key, and `gene` as the output space."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 3,
+   "id": "RGSE",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "def perturbmean_metadata_cb(ad: anndata.AnnData, metadata: dict):\n",
+    "    ad.obs[\"drug\"] = ad.obs[\"drug\"].astype(\"category\")\n",
+    "    ad.obs[\"cell_line\"] = ad.obs[\"cell_line\"].astype(\"category\")\n",
+    "\n",
+    "    metadata[\"input_dim\"] = ad.var.shape[0]\n",
+    "    metadata[\"output_dim\"] = ad.var.shape[0]\n",
+    "    metadata[\"hidden_dim\"] = 0  # hidden_dim: Not used here, but required by base-class signature.\n",
+    "    metadata[\"pert_dim\"] = ad.obs[\"drug\"].astype(str).nunique()\n",
+    "    metadata[\"lr\"] = 1e-3\n",
+    "\n",
+    "    metadata[\"gene_names\"] = ad.var_names.tolist()\n",
+    "    metadata[\"pert_names\"] = ad.obs[\"drug\"].cat.categories.tolist()\n",
+    "    metadata[\"cell_types\"] = ad.obs[\"cell_line\"].cat.categories.tolist()\n",
+    "    metadata[\"control_pert\"] = \"DMSO_TF\"\n",
+    "    metadata[\"embed_key\"] = \"X\"\n",
+    "    metadata[\"output_space\"] = \"gene\""
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "Kclp",
+   "metadata": {},
+   "source": [
+    "### Perturbation Dataset for Training (PerturbAnnDataset)\n",
+    "`PerturbAnnDataset` prepares batches for the **Perturbation Mean** model. It loads expression data, collects `drug` and `cell_line` metadata, and returns a dictionary containing perturbation names, cell types, and the corresponding expression features (used both as counts and embeddings) for training."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 4,
+   "id": "emfo",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "class PerturbAnnDataset(DistributedAnnDataset):\n",
+    "    def transform(self, start: int, end: int):\n",
+    "        X = super().transform(start, end)\n",
+    "\n",
+    "        # Metadata froms self.ad\n",
+    "        pert_names = self.ad.obs[\"drug\"].iloc[start:end].astype(str).to_list()\n",
+    "        cell_lines = self.ad.obs[\"cell_line\"].iloc[start:end].astype(str).to_list()\n",
+    "\n",
+    "        return {\n",
+    "            \"pert_name\": pert_names,\n",
+    "            \"cell_type\": cell_lines,\n",
+    "            \"pert_cell_counts\": X,\n",
+    "            \"pert_cell_emb\": X,\n",
+    "        }"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "Hstk",
+   "metadata": {},
+   "source": [
+    "### Extending STATE Models\n",
+    "The **STATE** framework provides baseline model classes such as `PerturbMeanPerturbationModel`, which can be imported and used directly.\n",
+    "To customize behavior, you can **extend an existing class** and override only the methods that need modification.  \n",
+    "In the example below, we subclass `PerturbMeanPerturbationModel` and redefine the `forward()` method. Rather than relying on the per-cell `ctrl_cell_emb`, the model predicts using only the **global basal vector** combined with the corresponding perturbation offset."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 5,
+   "id": "nWHF",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "class PerturbMeanGlobalModel(PerturbMeanPerturbationModel):\n",
+    "    \"\"\"\n",
+    "    Extended class of PerturbMeanPerturbationModel where prediction ignores\n",
+    "    per-cell control embedding and uses only global basal + offset.\n",
+    "    \"\"\"\n",
+    "\n",
+    "    def forward(self, batch: dict) -> torch.Tensor:\n",
+    "        B = len(batch[\"pert_name\"])\n",
+    "        device = self.dummy_param.device\n",
+    "        pred_out = torch.zeros((B, self.output_dim), device=device)\n",
+    "\n",
+    "        for i in range(B):\n",
+    "            p_name = str(batch[\"pert_name\"][i])\n",
+    "            offset_vec = self.pert_mean_offsets.get(p_name)\n",
+    "            if offset_vec is None:\n",
+    "                offset_vec = torch.zeros(self.output_dim, device=device)\n",
+    "\n",
+    "            # Use global basal instead of batch[\"ctrl_cell_emb\"]\n",
+    "            pred_out[i] = self.global_basal.to(device) + offset_vec.to(device)\n",
+    "\n",
+    "        return pred_out"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "af0e38aa",
+   "metadata": {},
+   "source": [
+    "### Training the model\n",
+    "- Collect statistics (`on_fit_start`)\n",
+    "    - Compute control means per cell type\n",
+    "    - Compute perturbation deltas\n",
+    "    - Average deltas across cell types → perturbation offsets\n",
+    "    - Compute global basal = mean of all control means.\n",
+    "- Forward: for each sample, `prediction = global_basal + offset[perturbation]`\n",
+    "- Training: no parameters are learned; only logs MSE loss vs. ground truth"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 6,
+   "id": "iLit",
+   "metadata": {
+    "scrolled": true
+   },
+   "outputs": [
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "2025-09-29 16:31:51,373\tINFO worker.py:1951 -- Started a local Ray instance.\n",
+      "2025-09-29 16:31:52,487\tINFO packaging.py:588 -- Creating a file package for local module '/mnt/hdd1/dung/protoplast-ml-example'.\n",
+      "2025-09-29 16:31:52,625\tWARNING packaging.py:430 -- File /mnt/hdd1/dung/protoplast-ml-example/.git/modules/submodules/SIMS/objects/pack/pack-682433dc4cf8becc2b44606f464dde9068565261.pack is very large (34.70MiB). Consider adding this file to the 'excludes' list to skip uploading it: `ray.init(..., runtime_env={'excludes': ['/mnt/hdd1/dung/protoplast-ml-example/.git/modules/submodules/SIMS/objects/pack/pack-682433dc4cf8becc2b44606f464dde9068565261.pack']})`\n",
+      "2025-09-29 16:31:52,853\tINFO packaging.py:380 -- Pushing file package 'gcs://_ray_pkg_1f721884ccb69d33.zip' (70.69MiB) to Ray cluster...\n",
+      "2025-09-29 16:31:53,343\tINFO packaging.py:393 -- Successfully pushed file package 'gcs://_ray_pkg_1f721884ccb69d33.zip'.\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "CPU times: user 922 ms, sys: 799 ms, total: 1.72 s\n",
+      "Wall time: 10.8 s\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "\u001b[33m(raylet)\u001b[0m \u001b[1m\u001b[33mwarning\u001b[39m\u001b[0m\u001b[1m:\u001b[0m \u001b[1m`VIRTUAL_ENV=/mnt/hdd1/dung/protoplast-ml-example/.venv` does not match the project environment path `.venv` and will be ignored; use `--active` to target the active environment instead\u001b[0m\n",
+      "\u001b[33m(raylet)\u001b[0m Using CPython \u001b[36m3.11.13\u001b[39m\n",
+      "\u001b[33m(raylet)\u001b[0m Creating virtual environment at: \u001b[36m.venv\u001b[39m\n",
+      "\u001b[33m(raylet)\u001b[0m \u001b[2mInstalled \u001b[1m296 packages\u001b[0m \u001b[2min 377ms\u001b[0m\u001b[0m\n",
+      "\u001b[33m(raylet)\u001b[0m \u001b[1m\u001b[33mwarning\u001b[39m\u001b[0m\u001b[1m:\u001b[0m \u001b[1m`VIRTUAL_ENV=/mnt/hdd1/dung/protoplast-ml-example/.venv` does not match the project environment path `.venv` and will be ignored; use `--active` to target the active environment instead\u001b[0m\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "\u001b[36m(TrainTrainable pid=3371578)\u001b[0m ✓ Applied AnnDataFileManager patch, AnnData cannot be imported after the patch!\n",
+      "\u001b[36m(TrainTrainable pid=3371578)\u001b[0m ✓ Applied AnnDataFileManager patch, AnnData cannot be imported after the patch!\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "\u001b[33m(raylet)\u001b[0m \u001b[1m\u001b[33mwarning\u001b[39m\u001b[0m\u001b[1m:\u001b[0m \u001b[1m`VIRTUAL_ENV=/mnt/hdd1/dung/protoplast-ml-example/.venv` does not match the project environment path `.venv` and will be ignored; use `--active` to target the active environment instead\u001b[0m\n",
+      "\u001b[36m(RayTrainWorker pid=3372413)\u001b[0m Setting up process group for: env:// [rank=0, world_size=1]\n",
+      "\u001b[36m(TorchTrainer pid=3371578)\u001b[0m Started distributed worker processes: \n",
+      "\u001b[36m(TorchTrainer pid=3371578)\u001b[0m - (node_id=b8b683fd763132fb5be6d98f0e4d56e917dd267ccfd076f40669efc5, ip=192.168.1.226, pid=3372413) world_rank=0, local_rank=0, node_rank=0\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "\u001b[36m(RayTrainWorker pid=3372413)\u001b[0m ✓ Applied AnnDataFileManager patch, AnnData cannot be imported after the patch!\n",
+      "\u001b[36m(RayTrainWorker pid=3372413)\u001b[0m ✓ Applied AnnDataFileManager patch, AnnData cannot be imported after the patch!\n",
+      "\u001b[36m(RayTrainWorker pid=3372413)\u001b[0m =========Starting the training on 0 with num threads: 4=========\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "\u001b[36m(RayTrainWorker pid=3372413)\u001b[0m 💡 Tip: For seamless cloud uploads and versioning, try installing [litmodels](https://pypi.org/project/litmodels/) to enable LitModelCheckpoint, which syncs automatically with the Lightning model registry.\n",
+      "\u001b[36m(RayTrainWorker pid=3372413)\u001b[0m GPU available: True (cuda), used: True\n",
+      "\u001b[36m(RayTrainWorker pid=3372413)\u001b[0m TPU available: False, using: 0 TPU cores\n",
+      "\u001b[36m(RayTrainWorker pid=3372413)\u001b[0m HPU available: False, using: 0 HPUs\n",
+      "\u001b[36m(RayTrainWorker pid=3372413)\u001b[0m You are using a CUDA device ('NVIDIA GeForce RTX 3080') that has Tensor Cores. To properly utilize them, you should set `torch.set_float32_matmul_precision('medium' | 'high')` which will trade-off precision for performance. For more details, read https://pytorch.org/docs/stable/generated/torch.set_float32_matmul_precision.html#torch.set_float32_matmul_precision\n",
+      "\u001b[36m(RayTrainWorker pid=3372413)\u001b[0m LOCAL_RANK: 0 - CUDA_VISIBLE_DEVICES: [0]\n",
+      "\u001b[36m(RayTrainWorker pid=3372413)\u001b[0m \n",
+      "\u001b[36m(RayTrainWorker pid=3372413)\u001b[0m   | Name         | Type    | Params | Mode \n",
+      "\u001b[36m(RayTrainWorker pid=3372413)\u001b[0m -------------------------------------------------\n",
+      "\u001b[36m(RayTrainWorker pid=3372413)\u001b[0m 0 | loss_fn      | MSELoss | 0      | train\n",
+      "\u001b[36m(RayTrainWorker pid=3372413)\u001b[0m   | other params | n/a     | 1      | n/a  \n",
+      "\u001b[36m(RayTrainWorker pid=3372413)\u001b[0m -------------------------------------------------\n",
+      "\u001b[36m(RayTrainWorker pid=3372413)\u001b[0m 1         Trainable params\n",
+      "\u001b[36m(RayTrainWorker pid=3372413)\u001b[0m 0         Non-trainable params\n",
+      "\u001b[36m(RayTrainWorker pid=3372413)\u001b[0m 1         Total params\n",
+      "\u001b[36m(RayTrainWorker pid=3372413)\u001b[0m 0.000     Total estimated model params size (MB)\n",
+      "\u001b[36m(RayTrainWorker pid=3372413)\u001b[0m 1         Modules in train mode\n",
+      "\u001b[36m(RayTrainWorker pid=3372413)\u001b[0m 0         Modules in eval mode\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Sanity Checking: |          | 0/? [00:00<?, ?it/s]\n",
+      "Sanity Checking DataLoader 0:   0%|          | 0/2 [00:00<?, ?it/s]\n",
+      "Sanity Checking DataLoader 0:  50%|█████     | 1/2 [00:00<00:00,  2.93it/s]\n",
+      "                                                                           \n",
+      "Epoch 0:   0%|          | 0/4160 [00:00<?, ?it/s] \n",
+      "Epoch 0:   0%|          | 1/4160 [00:23<27:27:04,  0.04it/s, v_num=0, train_loss=0.245]\n",
+      "Epoch 0:   0%|          | 2/4160 [00:24<13:54:30,  0.08it/s, v_num=0, train_loss=0.406]\n",
+      ".\n",
+      ".\n",
+      ".\n",
+      "Epoch 0: 100%|█████████▉| 4158/4160 [24:51<00:00,  2.79it/s, v_num=0, train_loss=0.365]\n",
+      "Epoch 0: 100%|█████████▉| 4159/4160 [24:52<00:00,  2.79it/s, v_num=0, train_loss=0.996]\n",
+      "Epoch 0: 100%|██████████| 4160/4160 [24:52<00:00,  2.79it/s, v_num=0, train_loss=0.474]\n",
+      "\u001b[36m(RayTrainWorker pid=3372413)\u001b[0m \n",
+      "Validation: |          | 0/? [00:00<?, ?it/s]\u001b[A\n",
+      "\u001b[36m(RayTrainWorker pid=3372413)\u001b[0m \n",
+      "Validation:   0%|          | 0/1024 [00:00<?, ?it/s]\u001b[A\n",
+      "Validation DataLoader 0:   0%|          | 0/1024 [00:00<?, ?it/s]\u001b[A\n",
+      "\u001b[36m(RayTrainWorker pid=3372413)\u001b[0m \n",
+      "Validation DataLoader 0:   0%|          | 1/1024 [00:00<05:03,  3.37it/s]\u001b[A\n",
+      "\u001b[36m(RayTrainWorker pid=3372413)\u001b[0m \n",
+      ".\n",
+      ".\n",
+      ".\n",
+      "Validation DataLoader 0: 100%|█████████▉| 1022/1024 [05:26<00:00,  3.13it/s]\u001b[A\n",
+      "\u001b[36m(RayTrainWorker pid=3372413)\u001b[0m \n",
+      "Validation DataLoader 0: 100%|█████████▉| 1023/1024 [05:27<00:00,  3.13it/s]\u001b[A\n",
+      "\u001b[36m(RayTrainWorker pid=3372413)\u001b[0m \n",
+      "Validation DataLoader 0: 100%|██████████| 1024/1024 [05:27<00:00,  3.13it/s]\u001b[A\n",
+      "\u001b[36m(RayTrainWorker pid=3372413)\u001b[0m \n",
+      "Epoch 0: 100%|██████████| 4160/4160 [30:51<00:00,  2.25it/s, v_num=0, train_loss=0.474]\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "\u001b[36m(RayTrainWorker pid=3372413)\u001b[0m Checkpoint successfully created at: Checkpoint(filesystem=local, path=/home/dtran/protoplast_results/TorchTrainer_2025-09-29_16-32-21/TorchTrainer_dfadf_00000_0_2025-09-29_16-32-22/checkpoint_000000)\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Epoch 0: 100%|██████████| 4160/4160 [30:53<00:00,  2.24it/s, v_num=0, train_loss=0.474]\n",
+      "Epoch 0: 100%|██████████| 4160/4160 [30:53<00:00,  2.24it/s, v_num=0, train_loss=0.474]\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "\u001b[36m(RayTrainWorker pid=3372413)\u001b[0m `Trainer.fit` stopped: `max_epochs=1` reached.\n"
+     ]
+    }
+   ],
+   "source": [
+    "%%time\n",
+    "PerturbMeanPerturbationModel_trainer = RayTrainRunner(\n",
+    "    PerturbMeanGlobalModel,\n",
+    "    PerturbAnnDataset,\n",
+    "    [\n",
+    "        \"input_dim\",\n",
+    "        \"output_dim\",\n",
+    "        \"hidden_dim\",\n",
+    "        \"pert_dim\",\n",
+    "        \"lr\",\n",
+    "        \"control_pert\",  # \"DMSO_TF\"\n",
+    "        \"embed_key\",\n",
+    "        \"output_space\",  # \"gene\"\n",
+    "    ],\n",
+    "    perturbmean_metadata_cb,\n",
+    ")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "ae11ae35",
+   "metadata": {},
+   "source": [
+    "On a machine with **1 GPU (NVIDIA GeForce RTX 3080 - 12 GiB)**, **96 CPUs**, and **125 GiB RAM**, running `PerturbMeanPerturbationModel_trainer.train()` completed in approximately **39 minutes**."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 7,
+   "id": "ZHCJ",
+   "metadata": {
+    "scrolled": true
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Setting thread_per_worker to half of the available CPUs capped at 4\n",
+      "Using 1 workers with {'CPU': 4} each\n",
+      "=========Length of val_split 65 length of test_split 0 length of train_split 262\n",
+      "=========Length of after dropping remainder val_split 64 length of test_split 0 length of train_split 260\n",
+      "Data splitting time: 24.26 seconds\n",
+      "Spawning Ray worker and initiating distributed training\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "2025-09-29 16:32:21,891\tINFO tune.py:616 -- [output] This uses the legacy output and progress reporter, as Jupyter notebooks are not supported by the new engine, yet. For more information, please see https://github.com/ray-project/ray/issues/36949\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "== Status ==\n",
+      "Current time: 2025-09-29 16:32:22 (running for 00:00:00.21)\n",
+      "Using FIFO scheduling algorithm.\n",
+      "Logical resource usage: 0/96 CPUs, 0/1 GPUs (0.0/1.0 accelerator_type:G)\n",
+      "Result logdir: /tmp/ray/session_2025-09-29_16-31-46_659688_3349722/artifacts/2025-09-29_16-32-21/TorchTrainer_2025-09-29_16-32-21/driver_artifacts\n",
+      "Number of trials: 1/1 (1 PENDING)\n",
+      "\n",
+      "\n",
+      "== Status ==\n",
+      "Current time: 2025-09-29 16:32:52 (running for 00:00:30.46)\n",
+      "Using FIFO scheduling algorithm.\n",
+      "Logical resource usage: 5.0/96 CPUs, 1.0/1 GPUs (0.0/1.0 accelerator_type:G)\n",
+      "Result logdir: /tmp/ray/session_2025-09-29_16-31-46_659688_3349722/artifacts/2025-09-29_16-32-21/TorchTrainer_2025-09-29_16-32-21/driver_artifacts\n",
+      "Number of trials: 1/1 (1 RUNNING)\n",
+      "\n",
+      "\n",
+      "== Status ==\n",
+      "Current time: 2025-09-29 17:10:45 (running for 00:38:23.50)\n",
+      "Using FIFO scheduling algorithm.\n",
+      "Logical resource usage: 5.0/96 CPUs, 1.0/1 GPUs (0.0/1.0 accelerator_type:G)\n",
+      "Result logdir: /tmp/ray/session_2025-09-29_16-31-46_659688_3349722/artifacts/2025-09-29_16-32-21/TorchTrainer_2025-09-29_16-32-21/driver_artifacts\n",
+      "Number of trials: 1/1 (1 RUNNING)\n",
+      "\n",
+      "\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "2025-09-29 17:10:50,421\tINFO tune.py:1009 -- Wrote the latest version of all result files and experiment state to '/home/dtran/protoplast_results/TorchTrainer_2025-09-29_16-32-21' in 0.1060s.\n",
+      "2025-09-29 17:10:50,471\tINFO tune.py:1041 -- Total run time: 2308.58 seconds (2307.96 seconds for the tuning loop).\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "== Status ==\n",
+      "Current time: 2025-09-29 17:10:50 (running for 00:38:28.07)\n",
+      "Using FIFO scheduling algorithm.\n",
+      "Logical resource usage: 5.0/96 CPUs, 1.0/1 GPUs (0.0/1.0 accelerator_type:G)\n",
+      "Result logdir: /tmp/ray/session_2025-09-29_16-31-46_659688_3349722/artifacts/2025-09-29_16-32-21/TorchTrainer_2025-09-29_16-32-21/driver_artifacts\n",
+      "Number of trials: 1/1 (1 TERMINATED)\n",
+      "\n",
+      "\n",
+      "CPU times: user 55.3 s, sys: 13.4 s, total: 1min 8s\n",
+      "Wall time: 38min 53s\n"
+     ]
+    },
+    {
+     "data": {
+      "text/plain": [
+       "Result(\n",
+       "  metrics={'train_loss': 0.47350403666496277, 'val_loss': 0.5732423067092896, 'epoch': 0, 'step': 4160},\n",
+       "  path='/home/dtran/protoplast_results/TorchTrainer_2025-09-29_16-32-21/TorchTrainer_dfadf_00000_0_2025-09-29_16-32-22',\n",
+       "  filesystem='local',\n",
+       "  checkpoint=Checkpoint(filesystem=local, path=/home/dtran/protoplast_results/TorchTrainer_2025-09-29_16-32-21/TorchTrainer_dfadf_00000_0_2025-09-29_16-32-22/checkpoint_000000)\n",
+       ")"
+      ]
+     },
+     "execution_count": 7,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "%%time\n",
+    "PerturbMeanPerturbationModel_trainer.train(\n",
+    "    file_paths,\n",
+    "    batch_size,  # 2000\n",
+    "    test_size,  # 0.0\n",
+    "    val_size,  # 0.2\n",
+    ")"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 8,
+   "id": "fb929268-60a8-4650-89a2-f906e17e0abc",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import ray\n",
+    "ray.shutdown()"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "ROlb",
+   "metadata": {},
+   "source": [
+    "## 3. EmbedSum\n",
+    "The **EmbedSumPerturbationModel** (part of the STATE framework) is a neural embedding model that predicts gene expression under perturbations.  \n",
+    "It works by combining a **control (basal) cell state** with a **learned perturbation embedding**.  \n",
+    "**Inputs**\n",
+    "  - Control (basal) expression counts or embedding  \n",
+    "  - Perturbation one-hot vector  \n",
+    "\n",
+    "**Output**\n",
+    "  - Predicted gene expression profile  \n",
+    "**Source code:** [embed_sum.py](https://github.com/ArcInstitute/state/blob/b6d26731e41d78c8c789d6973fe3d7db7853e9ad/src/state/tx/models/embed_sum.py#L7)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "qnkX",
+   "metadata": {},
+   "source": [
+    "### Metadata Callback\n",
+    "The `embedsum_metadata_cb` function prepares metadata for the `EmbedSumPerturbationModel`. It sets the input and output dimensions (equal to the **number of genes**), defines the perturbation dimension based on the unique drugs in the dataset, and specifies training parameters such as hidden layer size and the control perturbation (`DMSO_TF`)."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 9,
+   "id": "TqIu",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "def embedsum_metadata_cb(ad: anndata.AnnData, metadata: dict):\n",
+    "    cell_line_metadata_cb(ad, metadata)\n",
+    "    metadata[\"input_dim\"] = ad.var.shape[0]\n",
+    "    metadata[\"output_dim\"] = ad.var.shape[0]\n",
+    "\n",
+    "    uniq_drugs = sorted(ad.obs[\"drug\"].astype(str).unique().tolist())\n",
+    "    metadata[\"pert_dim\"] = len(uniq_drugs)\n",
+    "\n",
+    "    metadata[\"hidden_dim\"] = 10  # here kept small for testing\n",
+    "    metadata[\"control_pert\"] = \"DMSO_TF\""
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "Vxnm",
+   "metadata": {},
+   "source": [
+    "### EmbedSumAnnDataset\n",
+    "The `EmbedSumAnnDataset` class extends `DistributedAnnDataset` and prepares batches for the `EmbedSumPerturbationModel`. It enriches each batch with drug embeddings, metadata, and control information needed for training."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 10,
+   "id": "DnEU",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "class EmbedSumAnnDataset(DistributedAnnDataset):\n",
+    "    control_drug = \"DMSO_TF\"\n",
+    "\n",
+    "    def transform(self, start: int, end: int):\n",
+    "        # Loads gene expression (X) and converts it into a tensor (target_gene_expr).\n",
+    "        X = super().transform(start, end)\n",
+    "        target_gene_expr = torch.as_tensor(X, dtype=torch.float32)\n",
+    "        device = target_gene_expr.device\n",
+    "\n",
+    "        # Collects metadata: perturbation names (drug) and cell line labels\n",
+    "        pert_names = self.ad.obs[\"drug\"].iloc[start:end].astype(str).to_list()\n",
+    "        cell_lines = self.ad.obs[\"cell_line\"].iloc[start:end].astype(str).to_list()\n",
+    "\n",
+    "        # Create drug index mapping\n",
+    "        if not hasattr(self, \"_drug_to_idx\"):\n",
+    "            drug_names = sorted(self.ad.obs[\"drug\"].astype(str).unique())\n",
+    "            self._drug_to_idx = {d: i for i, d in enumerate(drug_names)}\n",
+    "            self._num_drugs = len(drug_names)\n",
+    "\n",
+    "        # encodes drugs as one-hot embeddings\n",
+    "        idxs = [self._drug_to_idx.get(p, 0) for p in pert_names]\n",
+    "        pert_emb = torch.nn.functional.one_hot(torch.tensor(idxs, device=device), num_classes=self._num_drugs).float()\n",
+    "\n",
+    "        # Computes a global control mean expression vector from cells treated with DMSO_TF\n",
+    "        if not hasattr(self, \"_ctrl_global\"):\n",
+    "            mask = self.ad.obs[\"drug\"] == self.control_drug\n",
+    "            if mask.sum() == 0:\n",
+    "                ctrl_vec = np.zeros(self.ad.shape[1], dtype=np.float32)\n",
+    "            else:\n",
+    "                ctrl_vec = np.asarray(self.ad[mask].X.mean(axis=0)).ravel().astype(np.float32)\n",
+    "            self._ctrl_global = torch.from_numpy(ctrl_vec)\n",
+    "\n",
+    "        ctrl_cell_emb = self._ctrl_global.to(device).unsqueeze(0).expand(len(pert_names), -1)\n",
+    "\n",
+    "        # Returns a dictionary containing embeddings, control features, target expression, and metadata for perturbation training\n",
+    "        return {\n",
+    "            \"pert_emb\": pert_emb,\n",
+    "            \"ctrl_cell_emb\": ctrl_cell_emb,\n",
+    "            \"target_gene_expr\": target_gene_expr,\n",
+    "            \"pert_cell_emb\": target_gene_expr,\n",
+    "            \"pert_name\": pert_names,\n",
+    "            \"cell_type\": cell_lines,\n",
+    "        }"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "ulZA",
+   "metadata": {},
+   "source": [
+    "### Training the EmbedSumPerturbationModel\n",
+    "- It pairs the model with the custom `EmbedSumAnnDataset` and passes in required arguments (dimensions, learning rate, control perturbation, embedding key, and output space) via `embedsum_metadata_cb`."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 11,
+   "id": "ecfG",
+   "metadata": {
+    "scrolled": true
+   },
+   "outputs": [
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "2025-09-29 17:13:50,011\tINFO worker.py:1951 -- Started a local Ray instance.\n",
+      "2025-09-29 17:13:50,728\tINFO packaging.py:588 -- Creating a file package for local module '/mnt/hdd1/dung/protoplast-ml-example'.\n",
+      "2025-09-29 17:13:50,874\tWARNING packaging.py:430 -- File /mnt/hdd1/dung/protoplast-ml-example/.git/modules/submodules/SIMS/objects/pack/pack-682433dc4cf8becc2b44606f464dde9068565261.pack is very large (34.70MiB). Consider adding this file to the 'excludes' list to skip uploading it: `ray.init(..., runtime_env={'excludes': ['/mnt/hdd1/dung/protoplast-ml-example/.git/modules/submodules/SIMS/objects/pack/pack-682433dc4cf8becc2b44606f464dde9068565261.pack']})`\n",
+      "2025-09-29 17:13:51,105\tINFO packaging.py:380 -- Pushing file package 'gcs://_ray_pkg_3e11bd015efed140.zip' (70.55MiB) to Ray cluster...\n",
+      "2025-09-29 17:13:51,625\tINFO packaging.py:393 -- Successfully pushed file package 'gcs://_ray_pkg_3e11bd015efed140.zip'.\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "CPU times: user 679 ms, sys: 748 ms, total: 1.43 s\n",
+      "Wall time: 11.9 s\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "\u001b[33m(raylet)\u001b[0m \u001b[1m\u001b[33mwarning\u001b[39m\u001b[0m\u001b[1m:\u001b[0m \n",
+      "\u001b[33m(raylet)\u001b[0m \u001b[1m`VIRTUAL_ENV=/mnt/hdd1/dung/protoplast-ml-example/.venv` does not match the project environment path `.venv` and will be ignored; use `--active` to target the active environment instead\u001b[0m\n",
+      "\u001b[33m(raylet)\u001b[0m Using CPython \u001b[36m3.11.13\u001b[39m\n",
+      "\u001b[33m(raylet)\u001b[0m Creating virtual environment at: \u001b[36m.venv\u001b[39m\n",
+      "\u001b[33m(raylet)\u001b[0m \u001b[2mInstalled \u001b[1m296 packages\u001b[0m \u001b[2min 347ms\u001b[0m\u001b[0m\n",
+      "\u001b[33m(raylet)\u001b[0m \u001b[1m\u001b[33mwarning\u001b[39m\u001b[0m\u001b[1m:\u001b[0m \u001b[1m`VIRTUAL_ENV=/mnt/hdd1/dung/protoplast-ml-example/.venv` does not match the project environment path `.venv` and will be ignored; use `--active` to target the active environment instead\u001b[0m\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "\u001b[36m(TrainTrainable pid=3410205)\u001b[0m ✓ Applied AnnDataFileManager patch, AnnData cannot be imported after the patch!\n",
+      "\u001b[36m(TrainTrainable pid=3410205)\u001b[0m ✓ Applied AnnDataFileManager patch, AnnData cannot be imported after the patch!\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "\u001b[33m(raylet)\u001b[0m \u001b[1m\u001b[33mwarning\u001b[39m\u001b[0m\u001b[1m:\u001b[0m \u001b[1m`VIRTUAL_ENV=/mnt/hdd1/dung/protoplast-ml-example/.venv` does not match the project environment path `.venv` and will be ignored; use `--active` to target the active environment instead\u001b[0m\n",
+      "\u001b[36m(RayTrainWorker pid=3410711)\u001b[0m Setting up process group for: env:// [rank=0, world_size=1]\n",
+      "\u001b[36m(TorchTrainer pid=3410205)\u001b[0m Started distributed worker processes: \n",
+      "\u001b[36m(TorchTrainer pid=3410205)\u001b[0m - (node_id=285a3d5c7ed27d7c54d3177df3fb09f94e0b897acd99ca14b9cb0bb5, ip=192.168.1.226, pid=3410711) world_rank=0, local_rank=0, node_rank=0\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "\u001b[36m(RayTrainWorker pid=3410711)\u001b[0m ✓ Applied AnnDataFileManager patch, AnnData cannot be imported after the patch!\n",
+      "\u001b[36m(RayTrainWorker pid=3410711)\u001b[0m ✓ Applied AnnDataFileManager patch, AnnData cannot be imported after the patch!\n",
+      "\u001b[36m(RayTrainWorker pid=3410711)\u001b[0m =========Starting the training on 0 with num threads: 4=========\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "\u001b[36m(RayTrainWorker pid=3410711)\u001b[0m 💡 Tip: For seamless cloud uploads and versioning, try installing [litmodels](https://pypi.org/project/litmodels/) to enable LitModelCheckpoint, which syncs automatically with the Lightning model registry.\n",
+      "\u001b[36m(RayTrainWorker pid=3410711)\u001b[0m GPU available: True (cuda), used: True\n",
+      "\u001b[36m(RayTrainWorker pid=3410711)\u001b[0m TPU available: False, using: 0 TPU cores\n",
+      "\u001b[36m(RayTrainWorker pid=3410711)\u001b[0m HPU available: False, using: 0 HPUs\n",
+      "\u001b[36m(RayTrainWorker pid=3410711)\u001b[0m You are using a CUDA device ('NVIDIA GeForce RTX 3080') that has Tensor Cores. To properly utilize them, you should set `torch.set_float32_matmul_precision('medium' | 'high')` which will trade-off precision for performance. For more details, read https://pytorch.org/docs/stable/generated/torch.set_float32_matmul_precision.html#torch.set_float32_matmul_precision\n",
+      "\u001b[36m(RayTrainWorker pid=3410711)\u001b[0m LOCAL_RANK: 0 - CUDA_VISIBLE_DEVICES: [0]\n",
+      "\u001b[36m(RayTrainWorker pid=3410711)\u001b[0m \n",
+      "\u001b[36m(RayTrainWorker pid=3410711)\u001b[0m   | Name          | Type       | Params | Mode \n",
+      "\u001b[36m(RayTrainWorker pid=3410711)\u001b[0m -----------------------------------------------------\n",
+      "\u001b[36m(RayTrainWorker pid=3410711)\u001b[0m 0 | loss_fn       | MSELoss    | 0      | train\n",
+      "\u001b[36m(RayTrainWorker pid=3410711)\u001b[0m 1 | pert_encoder  | Sequential | 1.1 K  | train\n",
+      "\u001b[36m(RayTrainWorker pid=3410711)\u001b[0m 2 | basal_encoder | Sequential | 627 K  | train\n",
+      "\u001b[36m(RayTrainWorker pid=3410711)\u001b[0m 3 | project_out   | Sequential | 689 K  | train\n",
+      "\u001b[36m(RayTrainWorker pid=3410711)\u001b[0m -----------------------------------------------------\n",
+      "\u001b[36m(RayTrainWorker pid=3410711)\u001b[0m 1.3 M     Trainable params\n",
+      "\u001b[36m(RayTrainWorker pid=3410711)\u001b[0m 0         Non-trainable params\n",
+      "\u001b[36m(RayTrainWorker pid=3410711)\u001b[0m 1.3 M     Total params\n",
+      "\u001b[36m(RayTrainWorker pid=3410711)\u001b[0m 5.273     Total estimated model params size (MB)\n",
+      "\u001b[36m(RayTrainWorker pid=3410711)\u001b[0m 16        Modules in train mode\n",
+      "\u001b[36m(RayTrainWorker pid=3410711)\u001b[0m 0         Modules in eval mode\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Sanity Checking: |          | 0/? [00:00<?, ?it/s]\n",
+      "Sanity Checking DataLoader 0:   0%|          | 0/2 [00:00<?, ?it/s]\n",
+      "Sanity Checking DataLoader 0:  50%|█████     | 1/2 [00:00<00:00,  6.13it/s]\n",
+      "                                                                           \n",
+      "Epoch 0:   0%|          | 0/4160 [00:00<?, ?it/s] \n",
+      "Epoch 0:   0%|          | 1/4160 [00:52<60:48:48,  0.02it/s, v_num=0]\n",
+      "Epoch 0:   0%|          | 2/4160 [00:55<31:51:02,  0.04it/s, v_num=0]\n",
+      ".\n",
+      ".\n",
+      ".\n",
+      "Epoch 0: 100%|█████████▉| 4158/4160 [19:34<00:00,  3.54it/s, v_num=0]\n",
+      "Epoch 0: 100%|█████████▉| 4159/4160 [19:34<00:00,  3.54it/s, v_num=0]\n",
+      "Epoch 0: 100%|██████████| 4160/4160 [19:34<00:00,  3.54it/s, v_num=0]\n",
+      "\u001b[36m(RayTrainWorker pid=3410711)\u001b[0m \n",
+      "Validation: |          | 0/? [00:00<?, ?it/s]\u001b[A\n",
+      "\u001b[36m(RayTrainWorker pid=3410711)\u001b[0m \n",
+      "Validation:   0%|          | 0/1024 [00:00<?, ?it/s]\u001b[A\n",
+      "Validation DataLoader 0:   0%|          | 0/1024 [00:00<?, ?it/s]\u001b[A\n",
+      "Validation DataLoader 0:   0%|          | 1/1024 [00:00<00:17, 59.34it/s]\u001b[A\n",
+      "\u001b[36m(RayTrainWorker pid=3410711)\u001b[0m \n",
+      "Validation DataLoader 0:   0%|          | 2/1024 [00:00<02:39,  6.43it/s]\u001b[A\n",
+      "\u001b[36m(RayTrainWorker pid=3410711)\u001b[0m \n",
+      ".\n",
+      ".\n",
+      ".\n",
+      "Validation DataLoader 0: 100%|██████████| 1024/1024 [04:35<00:00,  3.72it/s]\u001b[A\n",
+      "Epoch 0: 100%|██████████| 4160/4160 [24:34<00:00,  2.82it/s, v_num=0]       \u001b[A\n",
+      "Epoch 0: 100%|██████████| 4160/4160 [24:34<00:00,  2.82it/s, v_num=0]\n",
+      "Epoch 0: 100%|██████████| 4160/4160 [24:34<00:00,  2.82it/s, v_num=0]\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "\u001b[36m(RayTrainWorker pid=3410711)\u001b[0m Checkpoint successfully created at: Checkpoint(filesystem=local, path=/home/dtran/protoplast_results/TorchTrainer_2025-09-29_17-14-19/TorchTrainer_bc5c2_00000_0_2025-09-29_17-14-19/checkpoint_000000)\n",
+      "\u001b[36m(RayTrainWorker pid=3410711)\u001b[0m `Trainer.fit` stopped: `max_epochs=1` reached.\n",
+      "\u001b[36m(RayTrainWorker pid=3410711)\u001b[0m [rank0]:[W929 17:40:51.121165504 ProcessGroupNCCL.cpp:1538] Warning: WARNING: destroy_process_group() was not called before program exit, which can leak resources. For more info, please see https://pytorch.org/docs/stable/distributed.html#shutdown (function operator())\n"
+     ]
+    }
+   ],
+   "source": [
+    "%%time\n",
+    "EmbedSumPerturbationModel_trainer = RayTrainRunner(\n",
+    "    EmbedSumPerturbationModel,\n",
+    "    EmbedSumAnnDataset,\n",
+    "    [\n",
+    "        \"input_dim\",\n",
+    "        \"output_dim\",\n",
+    "        \"hidden_dim\",\n",
+    "        \"pert_dim\",\n",
+    "        \"lr\",\n",
+    "        \"control_pert\",  # \"DMSO_TF\"\n",
+    "        \"embed_key\",\n",
+    "        \"output_space\",  # \"gene\"\n",
+    "    ],\n",
+    "    embedsum_metadata_cb,\n",
+    ")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "77ff4544",
+   "metadata": {},
+   "source": [
+    "On a machine with **1 GPU (NVIDIA GeForce RTX 3080 - 12 GiB)**, **96 CPUs**, and **125 GiB RAM**, running `EmbedSumPerturbationModel_trainer.train()` completed in approximately **27 minutes**."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 12,
+   "id": "Pvdt",
+   "metadata": {
+    "scrolled": true
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Setting thread_per_worker to half of the available CPUs capped at 4\n",
+      "Using 1 workers with {'CPU': 4} each\n",
+      "=========Length of val_split 65 length of test_split 0 length of train_split 262\n",
+      "=========Length of after dropping remainder val_split 64 length of test_split 0 length of train_split 260\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "2025-09-29 17:14:19,631\tINFO tune.py:616 -- [output] This uses the legacy output and progress reporter, as Jupyter notebooks are not supported by the new engine, yet. For more information, please see https://github.com/ray-project/ray/issues/36949\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Data splitting time: 24.40 seconds\n",
+      "Spawning Ray worker and initiating distributed training\n",
+      "== Status ==\n",
+      "Current time: 2025-09-29 17:14:19 (running for 00:00:00.16)\n",
+      "Using FIFO scheduling algorithm.\n",
+      "Logical resource usage: 0/96 CPUs, 0/1 GPUs (0.0/1.0 accelerator_type:G)\n",
+      "Result logdir: /tmp/ray/session_2025-09-29_17-13-43_388460_3349722/artifacts/2025-09-29_17-14-19/TorchTrainer_2025-09-29_17-14-19/driver_artifacts\n",
+      "Number of trials: 1/1 (1 PENDING)\n",
+      "\n",
+      "\n",
+      "== Status ==\n",
+      "Current time: 2025-09-29 17:14:55 (running for 00:00:35.42)\n",
+      "Using FIFO scheduling algorithm.\n",
+      "Logical resource usage: 5.0/96 CPUs, 1.0/1 GPUs (0.0/1.0 accelerator_type:G)\n",
+      "Result logdir: /tmp/ray/session_2025-09-29_17-13-43_388460_3349722/artifacts/2025-09-29_17-14-19/TorchTrainer_2025-09-29_17-14-19/driver_artifacts\n",
+      "Number of trials: 1/1 (1 RUNNING)\n",
+      "\n",
+      "\n",
+      "== Status ==\n",
+      "Current time: 2025-09-29 17:40:49 (running for 00:26:30.11)\n",
+      "Using FIFO scheduling algorithm.\n",
+      "Logical resource usage: 5.0/96 CPUs, 1.0/1 GPUs (0.0/1.0 accelerator_type:G)\n",
+      "Result logdir: /tmp/ray/session_2025-09-29_17-13-43_388460_3349722/artifacts/2025-09-29_17-14-19/TorchTrainer_2025-09-29_17-14-19/driver_artifacts\n",
+      "Number of trials: 1/1 (1 RUNNING)\n",
+      "\n",
+      "\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "2025-09-29 17:40:50,117\tINFO tune.py:1009 -- Wrote the latest version of all result files and experiment state to '/home/dtran/protoplast_results/TorchTrainer_2025-09-29_17-14-19' in 0.0069s.\n",
+      "2025-09-29 17:40:50,123\tINFO tune.py:1041 -- Total run time: 1590.49 seconds (1590.47 seconds for the tuning loop).\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "== Status ==\n",
+      "Current time: 2025-09-29 17:40:50 (running for 00:26:30.48)\n",
+      "Using FIFO scheduling algorithm.\n",
+      "Logical resource usage: 5.0/96 CPUs, 1.0/1 GPUs (0.0/1.0 accelerator_type:G)\n",
+      "Result logdir: /tmp/ray/session_2025-09-29_17-13-43_388460_3349722/artifacts/2025-09-29_17-14-19/TorchTrainer_2025-09-29_17-14-19/driver_artifacts\n",
+      "Number of trials: 1/1 (1 TERMINATED)\n",
+      "\n",
+      "\n",
+      "CPU times: user 45.4 s, sys: 9.44 s, total: 54.8 s\n",
+      "Wall time: 26min 54s\n"
+     ]
+    },
+    {
+     "data": {
+      "text/plain": [
+       "Result(\n",
+       "  metrics={'train_loss': 0.51564621925354, 'val_loss': 0.6005661487579346, 'epoch': 0, 'step': 4160},\n",
+       "  path='/home/dtran/protoplast_results/TorchTrainer_2025-09-29_17-14-19/TorchTrainer_bc5c2_00000_0_2025-09-29_17-14-19',\n",
+       "  filesystem='local',\n",
+       "  checkpoint=Checkpoint(filesystem=local, path=/home/dtran/protoplast_results/TorchTrainer_2025-09-29_17-14-19/TorchTrainer_bc5c2_00000_0_2025-09-29_17-14-19/checkpoint_000000)\n",
+       ")"
+      ]
+     },
+     "execution_count": 12,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "%%time\n",
+    "EmbedSumPerturbationModel_trainer.train(\n",
+    "    file_paths,\n",
+    "    batch_size,  # 2000\n",
+    "    test_size,  # 0.0\n",
+    "    val_size,  # 0.2\n",
+    ")"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "3701b7c6-d275-42a9-9819-8ed73b04d218",
+   "metadata": {},
+   "outputs": [],
+   "source": []
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3 (ipykernel)",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.11.13"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 5
 }


### PR DESCRIPTION
removed thread per workers, so now default values are used. Users do not need to specify thread per workers. 
re run notebooks after cloning new protoplast-ml-example followed the readme